### PR TITLE
Add unique class to title slide

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,4 +18,4 @@ Suggests: rstudioapi, testit
 License: MIT + file LICENSE
 URL: https://github.com/yihui/xaringan
 BugReports: https://github.com/yihui/xaringan/issues
-RoxygenNote: 5.0.1.9000
+RoxygenNote: 5.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,4 +18,4 @@ Suggests: rstudioapi, testit
 License: MIT + file LICENSE
 URL: https://github.com/yihui/xaringan
 BugReports: https://github.com/yihui/xaringan/issues
-RoxygenNote: 5.0.1
+RoxygenNote: 5.0.1.9000

--- a/inst/rmarkdown/templates/xaringan/resources/default.html
+++ b/inst/rmarkdown/templates/xaringan/resources/default.html
@@ -23,7 +23,7 @@ $endfor$
     <textarea id="source">
 $if(title-slide)$
 $if(title)$
-class: center, middle, inverse
+class: center, middle, inverse, title-slide
 
 # $title$
 $if(subtitle)$


### PR DESCRIPTION
Adds a unique class name, `title-slide`, to the title/seal slide so it is possible to make specific changes to the css that are applicable only to the title page such as adding an institution logo, changing font size etc.