### PR TITLE
adding countdown

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -73,7 +73,7 @@ moon_reader = function(
   countdown_js = NULL
   if (!is.null(countdown <- nature[['countdown']]) && countdown) {
 
-    countdown_js_raw <- "var c = setInterval(function(){}, 1000); var tot = slideshow.getSlideCount(); slideshow.on('afterShowSlide', function (slide) {var time_left = %d; var counter_div = document.getElementsByClassName('remark-slide-number').item(slide.getSlideIndex()); var cur = counter_div.innerHTML; function counter() { return window.setInterval(function() { time_left = time_left - 1000; counter_div.innerHTML = time_left/1000 + 's ' + (slide.getSlideIndex()+1) + ' / ' + tot; if (time_left < 0) counter_div.style.color = 'red';}, 1000);} clearInterval(c); c = counter();})"
+    countdown_js_raw <- readLines(system.file('/rmarkdown/templates/xaringan/resources/countdown.js', package = "xaringan"))
 
     if (is.numeric(autoplay <- nature[['autoplay']]) && autoplay > 0) {
       countdown_js = sprintf(countdown_js_raw, autoplay)
@@ -84,9 +84,6 @@ moon_reader = function(
         stop("Numeric value required for countdown")
       }
     }
-    if (!nature[['countIncrementalSlides']])
-      stop('Countdown is only supported if incremental slides are counted!')
-
   }
 
   nature[['autoplay_countdown']] = NULL

--- a/inst/rmarkdown/templates/xaringan/resources/countdown.js
+++ b/inst/rmarkdown/templates/xaringan/resources/countdown.js
@@ -1,0 +1,45 @@
+var c = setInterval(function(){}, 1000);
+t_span = function() {
+  var timerSpan = document.createElement('span');
+  timerSpan.setAttribute('id', 'time-left');
+  return timerSpan;
+};
+var timerSpan = t_span();
+var temp = document.getElementsByClassName('remark-slide-number').item(1);
+temp.appendChild(timerSpan);
+time_format = function(time_left) {
+  secs = Math.abs(time_left)/1000;
+  var h = Math.floor(secs / 3600);
+  var m = Math.floor((secs / 3600) %% 1 * 60);
+  var s = Math.floor((secs / 60) %% 1 * 60);
+  var res = s + 's ';
+  if (m > 0) {
+    res = m + 'm ' + res;
+  }
+  if (h > 0) {
+    res = h + 'h ' + res;
+  }
+  return res;
+};
+slideshow.on('afterShowSlide', function (slide) {
+  var time_left = %d;
+  var counter_div = document.getElementsByClassName('remark-slide-number').item(slide.getSlideIndex());
+  function counter() {
+    return window.setInterval(function() {
+      time_left = time_left - 1000;
+      t = time_format(time_left);
+      var span = document.getElementById('time-left');
+      span.parentNode.removeChild(span);
+      var timerSpan = t_span();
+      if (time_left >= 0) {
+        timerSpan.innerHTML = ' ' + t + ' Remaining';
+      } else {
+        timerSpan.innerHTML = ' ' + t + ' Over!';
+        counter_div.style.color = 'red';
+      }
+      counter_div.appendChild(timerSpan);
+    }, 1000);}
+  clearInterval(c);
+  c = counter();
+});
+

--- a/man/moon_reader.Rd
+++ b/man/moon_reader.Rd
@@ -5,10 +5,9 @@
 \alias{tsukuyomi}
 \title{An R Markdown output format for remark.js slides}
 \usage{
-moon_reader(css = "default", self_contained = FALSE, seal = TRUE,
-  yolo = FALSE,
-  chakra = "https://remarkjs.com/downloads/remark-latest.min.js",
-  nature = list(), ...)
+moon_reader(css = "default", self_contained = FALSE, seal = TRUE, yolo = FALSE, 
+    chakra = "https://remarkjs.com/downloads/remark-latest.min.js", nature = list(), 
+    ...)
 
 tsukuyomi(...)
 }

--- a/man/moon_reader.Rd
+++ b/man/moon_reader.Rd
@@ -5,9 +5,10 @@
 \alias{tsukuyomi}
 \title{An R Markdown output format for remark.js slides}
 \usage{
-moon_reader(css = "default", self_contained = FALSE, seal = TRUE, yolo = FALSE, 
-    chakra = "https://remarkjs.com/downloads/remark-latest.min.js", nature = list(), 
-    ...)
+moon_reader(css = "default", self_contained = FALSE, seal = TRUE,
+  yolo = FALSE,
+  chakra = "https://remarkjs.com/downloads/remark-latest.min.js",
+  nature = list(), ...)
 
 tsukuyomi(...)
 }
@@ -42,7 +43,10 @@ list(click = TRUE))}; see
 \url{https://github.com/gnab/remark/wiki/Configuration}. Besides the
 options provided by remark.js, you can also set \code{autoplay} to a number
 (the number of milliseconds) so the slides will be played every
-\code{autoplay} seconds.}
+\code{autoplay} milliseconds. You can also set \code{countdown} to a number
+(the number of milliseconds) to include a countdown on each slide. If using
+\code{autoplay}, you can optionally set \code{countdown} to \code{true} to
+include a countdown equal to \code{autoplay}.}
 
 \item{...}{For \code{tsukuyomi()}, arguments passed to \code{moon_reader()};
 for \code{moon_reader()}, arguments passed to


### PR DESCRIPTION
Added code to include an optional countdown timer on each slide. The timer can be used with or without autoplay. Using the timer does require that incremental slides are counted in the total. The counter argument displays time in seconds. The counter turns red if the timer goes negative. 

