### PR TITLE
replacement mathjax CDN

### DIFF
--- a/inst/rmarkdown/templates/xaringan/resources/default.html
+++ b/inst/rmarkdown/templates/xaringan/resources/default.html
@@ -61,7 +61,7 @@ MathJax.Hub.Config({
 (function () {
   var script = document.createElement('script');
   script.type = 'text/javascript';
-  script.src  = '$if(mathjax-url)$$mathjax-url$$else$https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML$endif$';
+  script.src  = '$if(mathjax-url)$$mathjax-url$$else$https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML$endif$';
   if (location.protocol !== 'file:' && /^https?:/.test(script.src))
     script.src  = script.src.replace(/^https?:/, '');
   document.getElementsByTagName('head')[0].appendChild(script);


### PR DESCRIPTION
MathJax CDN shutting down on April 30, 2017.
https://www.mathjax.org/cdn-shutting-down/
So, I replaced from `cdn.mathjax.org` to alternative CDN providers.