### PR TITLE
Adding multi line highlighting

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -119,37 +119,7 @@ moon_reader = function(
     function(x, options) {
       res = hook_source(x, options)
       # replace {{code}} with *code so that this line can be highlighted
-      # if highlighting on single line, replace
-      res = gsub('(^|\n)([ \t]*)\\{\\{([^\n]+?)\\}\\}', '\\1*\\2\\3', res)
-      # having done that check for multiline replacements
-      if (grepl('(^|\n)([ \t]*)\\{\\{(.+\n+.*)\\}\\}', res)) {
-        # find number of wrapped highlighted lines to sort out
-        n_rep = length(gregexpr('(^|\n)([ \t]*)\\{\\{([^\\}]{1,})\\}\\}', res)[[1]])
-        # for each one to replace
-        for (i in c(1:n_rep)) {
-          # find position of first string to replace
-          str_pos = regexpr('(^|\n)([ \t]*)\\{\\{([^\\}]{1,})\\}\\}', res)
-          start_position = as.numeric(str_pos)
-          end_position = start_position + attr(str_pos, "match.length")
-          # extract actual string to replace
-          string_to_replace =
-            regmatches(res, regexpr('(^|\n)([ \t]*)\\{\\{([^\\}]{1,})\\}\\}', res))[[1]]
-          # replace opening {{
-          string_to_replace = sub("(^|\n)([ \t]*)\\{\\{", "\\1*\\2", string_to_replace)
-          # add * to beginning of any other new lines
-          string_to_replace = gsub("\n([^\\*])", "\n*\\1", string_to_replace)
-          # remove closing }}
-          string_to_replace = sub("\\}\\}$", "", string_to_replace)
-          # split original string
-          res_split = strsplit(res, "")[[1]]
-          # put string back together but with replacement
-          res = paste0(paste0(res_split[1:(start_position - 1)],
-                              collapse = ""),
-                       string_to_replace,
-                       paste0(res_split[end_position:length(res_split)],
-                              collapse = ""))
-        }
-      }
+      res = highlight_code(res)
       return(res)
     }
   }

--- a/R/render.R
+++ b/R/render.R
@@ -135,7 +135,7 @@ moon_reader = function(
           string_to_replace =
             regmatches(res, regexpr('(^|\n)([ \t]*)\\{\\{([^\\}]{1,})\\}\\}', res))[[1]]
           # replace opening {{
-          string_to_replace = sub("(^|\n)([\\s]*)\\{\\{", "\\1*\\2", string_to_replace)
+          string_to_replace = sub("(^|\n)([ \t]*)\\{\\{", "\\1*\\2", string_to_replace)
           # add * to beginning of any other new lines
           string_to_replace = gsub("\n([^\\*])", "\n*\\1", string_to_replace)
           # remove closing }}

--- a/R/utils.R
+++ b/R/utils.R
@@ -116,3 +116,39 @@ summon_remark = function(version = 'latest', to = 'libs/') {
     file.path(to, name)
   )
 }
+
+
+highlight_code = function(x) {
+  # if highlighting on single line, replace
+  x = gsub('(^|\n)([ \t]*)\\{\\{([^\n]+?)\\}\\}', '\\1*\\2\\3', x)
+  # having done that check for multiline replacements
+  if (grepl('(^|\n)([ \t]*)\\{\\{(.+\n+.*)\\}\\}', x)) {
+    # find number of wrapped highlighted lines to sort out
+    n_rep = length(gregexpr('(^|\n)([ \t]*)\\{\\{([^\\}]{1,})\\}\\}', x)[[1]])
+    # for each one to replace
+    for (i in c(1:n_rep)) {
+      # find position of first string to replace
+      str_pos = regexpr('(^|\n)([ \t]*)\\{\\{([^\\}]{1,})\\}\\}', x)
+      start_position = as.numeric(str_pos)
+      end_position = start_position + attr(str_pos, "match.length")
+      # extract actual string to replace
+      string_to_replace =
+        regmatches(x, regexpr('(^|\n)([ \t]*)\\{\\{([^\\}]{1,})\\}\\}', x))[[1]]
+      # replace opening {{
+      string_to_replace = sub("(^|\n)([ \t]*)\\{\\{", "\\1*\\2", string_to_replace)
+      # add * to beginning of any other new lines
+      string_to_replace = gsub("\n([^\\*])", "\n*\\1", string_to_replace)
+      # remove closing }}
+      string_to_replace = sub("\\}\\}$", "", string_to_replace)
+      # split original string
+      x_split = strsplit(x, "")[[1]]
+      # put string back together but with replacement
+      x = paste0(paste0(x_split[1:(start_position - 1)],
+                          collapse = ""),
+                   string_to_replace,
+                   paste0(x_split[end_position:length(x_split)],
+                          collapse = ""))
+    }
+  }
+  return(x)
+}

--- a/xaringan.Rproj
+++ b/xaringan.Rproj
@@ -3,6 +3,7 @@ Version: 1.0
 RestoreWorkspace: Default
 SaveWorkspace: Default
 AlwaysSaveHistory: Default
+QuitChildProcessesOnExit: Default
 
 EnableCodeIndexing: Yes
 UseSpacesForTab: Yes

--- a/xaringan.Rproj
+++ b/xaringan.Rproj
@@ -3,7 +3,6 @@ Version: 1.0
 RestoreWorkspace: Default
 SaveWorkspace: Default
 AlwaysSaveHistory: Default
-QuitChildProcessesOnExit: Default
 
 EnableCodeIndexing: Yes
 UseSpacesForTab: Yes


### PR DESCRIPTION
As discussed in #53 added multiline highlighting. Tested using
````
---
title: "My Problem"
output:
  xaringan::moon_reader:
    lib_dir: libs
    nature:
      highlightStyle: github
      highlightLines: true
      countIncrementalSlides: false
---

```{r}
add1 <- function(x) x + 1
```

---

```{r}
## works
{{add1(2)}}
```

---

```{r}
## works
{{add1(
  add1(2)
)}}
```

---

```{r}
## works
add1(
  {{add1(2)}}
)
```

---

```{r}
## works
my_fn = function(){
{{data.frame(x = rnorm(10),
          y = rnorm(10))}}
}
```

---

```{r}
## works
my_fn = function(){
  {{num = 10}}
  
{{  dat = data.frame(x = rnorm(num),
                   y = rnorm(num))}}
  
{{  dat = cbind(dat, 
              z = 2*dat$x)}}
}
```
````
which seems to work. The only thing it doesn't sort automatically is indentation as you can see from the last two examples. Rmd, libs and html attached in zip file.
[xaringan_test.zip](https://github.com/yihui/xaringan/files/1075592/xaringan_test.zip)
