### PR TITLE
Feature suggestion: New line highlight marker `#<<`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -139,7 +139,7 @@ highlight_code = function(x) {
   m = gregexpr(r, x)
   regmatches(x, m) = lapply(regmatches(x, m), function(z) {
     z = gsub(r, '\\1\\2\\3', z)  # remove {{ and }}
-    z = gsub('\n', '\n*', z)     # add * after every \n
+    z = gsub('\n ?', '\n*', z)   # add * after every \n
     z
   })
   gsub('^\n', '', x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -142,7 +142,18 @@ highlight_code = function(x) {
     z = gsub('\n ?', '\n*', z)   # add * after every \n
     z
   })
-  gsub('^\n', '', x)
+  x = gsub('^\n', '', x)
+  highlight_code2(x)
+}
+
+# adds support for `#<<` line highlight marker at line end in code segments
+highlight_code2 = function(x) {
+  # Catch `#<<` at end of the line but ignores lines that start with `*`
+  # since they came from highlight_code(x)
+  x = strsplit(x, "\n")
+  r = "^[[:blank:]]?([^*].+?)[[:blank:]]*#<<[[:blank:]]*$"
+  x = lapply(x, gsub, pattern = r, replacement = "*\\1")
+  paste(unlist(x), collapse = "\n")
 }
 
 file_content = function(file) {

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -18,3 +18,21 @@ assert(
   protect_math('$$ a$$') %==% '$$ a$$',
   protect_math('$$a$') %==% '$$a$'
 )
+
+assert(
+  "highlight_code handles {{ .code. }} and ...code #<< formats",
+  highlight_code("{{paste('a')}}") %==% "*paste('a')",
+  highlight_code("paste('a') #<<") %==% "*paste('a')",
+  highlight_code(" {{paste('a')}}") %==% "*paste('a')",
+  highlight_code(" paste('a') #<<") %==% "*paste('a')",
+  highlight_code("{{paste('a')}} #<<") %==% "*paste('a') #<<",
+  highlight_code("*paste('a') #<<") %==% "*paste('a') #<<",
+  highlight_code("paste('a') #comment #<<") %==% "*paste('a') #comment",
+  highlight_code("paste('a') #<<    ") %==% "*paste('a')",
+  highlight_code("paste('a')    #<<    ") %==% "*paste('a')",
+  highlight_code("   paste('a') #<<") %==% "*  paste('a')",
+  highlight_code("*  paste('a') #<<") %==% "*  paste('a') #<<",
+  highlight_code("paste('a')#<<") %==% "*paste('a')",
+  # A space is added in following (can't overwrite first space when 2nd char is *)
+  highlight_code(" * paste('a') #<<") %==% "* * paste('a')"
+)


### PR DESCRIPTION
Line highlighting is an excellent feature, but I've found that the need to wrap a complete expression in the brace fences `{{ ...code.. }}` to be a little tricky at times.

My two pain points have been:

1. The code in the chunk looks different than it's rendered, and the alignment of wrapped lines in the source is off by one character (see #70).

2. I often don't get the fencing right on the first try because I include a character that is part of a longer expression and therefore the braced section isn't correct. For example, you can't just wrap a line in `{{ ...line... }}`, you have to make sure you get just the part of the line that is an expression: `{{arg = "something"}},` (note the trailing comma).

I realized I could get around this with a custom knitr source hook, but for the sake of the community I thought I'd submit this as a feature request. Totally understand if you don't want to clutter the xaringan api, but this solution has worked well for me so far.

The main addition of this PR is a new line highlighting marker in the form of `#<<`. Because it's a code comment, it's simply placed at the end of the line the user wants to highlight. It needs to be the last characters on the line (trailing whitespace is okay) and lines that start with `*` aren't highlighted so that the fence-style takes precedent.

For example, the last two lines of this code chunk would be highlighted:
````
```{r}
# New syntax
ggplot(mtcars) + 
  aes(mpg, disp) + 
  geom_point() +   #<<
  geom_smooth()    #<<
```
````

I like the cleanliness of this: the code alignment in the source matches the rendered output and the `#<<` points to the highlighted lines. It's also easy to add after the code is written without much thinking.

Using the fence style

````
```{r}
# Fence syntax
ggplot(mtcars) + 
  aes(mpg, disp) + 
  {{geom_point()}} +  
  {{geom_smooth()}}
```
````


I also updated the fence style so that if a line starts with a space, that space is replaced with the `*`. This makes it possible to maintain alignment in the source and output. In the previous version alignment would need to be as below to maintain alignment in the rendered source between `aes`, `geom_point` and `geom_smooth`

````
```{r}
# Current fence syntax
ggplot(mtcars) + 
  aes(mpg, disp) + 
 {{geom_point()}} +  
 {{geom_smooth()}}
```
````

All of the above should now output the following in the source chunk

```r
ggplot(mtcars) + 
  aes(mpg, disp) + 
* geom_point() + 
* geom_smooth()
```

And the rendered output will look something like this

![screenshot-2018-1-23 presentation ninja](https://user-images.githubusercontent.com/5420529/35292221-d6d210b0-003d-11e8-9e26-1dffe10fa580.png)

I tried to think through all the edge cases in the tests that I added, which cover a few more cases that I haven't discussed here.