### PR TITLE
Check built-in themes with check_builtin_css() before render

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,10 @@
 
 - In the `metropolis` theme, updated weights and margins of all headers, and added a new CSS class `clear` that disables the colored box at the top of each slide (#107).
 
+## BUG FIXES
+
+- An informative error message is now returned when trying to use an invalid or misspelled CSS theme name (thanks, @gadenbuie, #129).
+
 # CHANGES IN xaringan VERSION 0.6
 
 ## NEW FEATURES

--- a/R/render.R
+++ b/R/render.R
@@ -74,6 +74,7 @@ moon_reader = function(
   theme = grep('[.]css$', css, value = TRUE, invert = TRUE)
   deps = if (length(theme)) {
     css = setdiff(css, theme)
+    check_builtin_css(theme)
     list(css_deps(theme))
   }
   tmp_js = tempfile('xaringan', fileext = '.js')  # write JS config to this file

--- a/R/utils.R
+++ b/R/utils.R
@@ -22,15 +22,14 @@ list_css = function() {
 check_builtin_css = function(theme) {
   valid = names(list_css())
   invalid = setdiff(theme, valid)
-  if (!length(invalid)) return(invisible()) else {
-    invalid = invalid[1]
-    match_maybe = sort(agrep(invalid, valid, value = TRUE))[1]
-    match_text = if (!is.na(match_maybe)) paste0(', did you mean "', match_maybe, '"?') else ""
-    stop('"', invalid, '" is not a valid xaringan theme',
-         if (match_text != "") match_text else ".",
-         "\n       Use `xaringan:::list_css()` to view all themes.",
-         call. = FALSE)
-  }
+  if (length(invalid) == 0) return()
+  invalid = invalid[1]
+  match_maybe = sort(agrep(invalid, valid, value = TRUE))[1]
+  match_text = if (is.na(match_maybe)) '' else paste0(', did you mean "', match_maybe, '"?')
+  stop('"', invalid, '" is not a valid xaringan theme',
+       if (match_text != "") match_text else ".",
+       "\n       Use `xaringan:::list_css()` to view all themes.",
+       call. = FALSE)
 }
 
 split_yaml_body = function(file) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -19,6 +19,20 @@ list_css = function() {
   setNames(css, gsub('.css$', '', basename(css)))
 }
 
+check_builtin_css = function(theme) {
+  valid = names(list_css())
+  invalid = setdiff(theme, valid)
+  if (!length(invalid)) return(invisible()) else {
+    invalid = invalid[1]
+    match_maybe = sort(agrep(invalid, valid, value = TRUE))[1]
+    match_text = if (!is.na(match_maybe)) paste0(', did you mean "', match_maybe, '"?') else ""
+    stop('"', invalid, '" is not a valid xaringan theme',
+         if (match_text != "") match_text else ".",
+         "\n       Use `xaringan:::list_css()` to view all themes.",
+         call. = FALSE)
+  }
+}
+
 split_yaml_body = function(file) {
   x = readLines(file, encoding = 'UTF-8')
   i = grep('^---\\s*$', x)


### PR DESCRIPTION
This addresses #129 by adding an error message when a requested built-in theme is not available.

I named the check function `check_builtin_css()` as `check_css()` seemed ambiguous on second thought.

Personally, I like the behavior of xaringan with this PR a lot. If an incorrect theme is given, say `metropolis-font`, the error message is immediate. This helps signal that it's a configuration issue rather than an issue with code in the presentation. Also, the error message is helpful.

```
Error: "metropolis-font" is not a valid xaringan theme, did you mean "metropolis-fonts"?
       Use `xaringan:::list_css()` to view all themes.
Execution halted
```

The error stops on the first invalid theme name. This seemed a reasonable trade-off between returning a useful error message and adding the logic required to make a grammatically correct sentences when multiple themes are invalid.