### PR TITLE
Add title slide class arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: xaringan
 Type: Package
 Title: Presentation Ninja
-Version: 0.6.6
+Version: 0.6.7
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Claus Thorn", "Ekstrøm", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 - In the `metropolis` theme, updated weights and margins of all headers, and added a new CSS class `clear` that disables the colored box at the top of each slide (#107).
 
+- It is possible to customize the CSS classes of the title slide using the option `titleSlideClass` under the `nature` option of `xaringan::moon_reader()` now (thanks, @gadenbuie, #139, #136).
+
 ## BUG FIXES
 
 - An informative error message is now returned when trying to use an invalid or misspelled CSS theme name (thanks, @gadenbuie, #129).

--- a/R/render.R
+++ b/R/render.R
@@ -91,13 +91,12 @@ moon_reader = function(
     '(%s)(%d);', pkg_file('js/countdown.js'), countdown
   )
 
-  titleSlideClass <- if (!is.null(nature[['titleSlideClass']])) paste(
-    nature[['titleSlideClass']], collapse = ", "
-  ) else "center, middle, inverse"
+  if (is.null(title_cls <- nature[['titleSlideClass']]))
+    title_cls = c('center', 'middle', 'inverse')
+  title_cls = paste(c(title_cls, 'title-slide'), collapse = ", ")
 
   before = nature[['beforeInit']]
-  nature[['countdown']] = nature[['autoplay']] = nature[['beforeInit']] =
-    nature[["titleSlideClass"]] = NULL
+  for (i in c('countdown', 'autoplay', 'beforeInit', "titleSlideClass")) nature[[i]] = NULL
 
   write_utf8(as.character(tagList(
     tags$script(src = chakra),
@@ -124,10 +123,10 @@ moon_reader = function(
       if (identical(mathjax, 'default')) {
         mathjax = 'https://cdn.bootcss.com/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML'
       }
-      pandoc_args = c(pandoc_args, '-V', paste0('mathjax-url=', mathjax),
-                      "-V", paste0('title-slide-class=', titleSlideClass, ''))
+      pandoc_args = c(pandoc_args, '-V', paste0('mathjax-url=', mathjax))
       mathjax = NULL
     }
+    pandoc_args = c(pandoc_args, '-V', paste0('title-slide-class=', title_cls))
     rmarkdown::html_document(
       ..., includes = includes, mathjax = mathjax, pandoc_args = pandoc_args
     )

--- a/R/render.R
+++ b/R/render.R
@@ -41,7 +41,10 @@
 #'   \code{autoplay} milliseconds. You can also set \code{countdown} to a number
 #'   (the number of milliseconds) to include a countdown timer on each slide. If
 #'   using \code{autoplay}, you can optionally set \code{countdown} to
-#'   \code{TRUE} to include a countdown equal to \code{autoplay}.
+#'   \code{TRUE} to include a countdown equal to \code{autoplay}. To alter the
+#'   set of classes applied to the title slide, you can optionally set
+#'   \code{titleSlideClass} to a vector of classes; the default is
+#'   \code{c("center", "middle", "inverse")}.
 #' @param ... For \code{tsukuyomi()}, arguments passed to \code{moon_reader()};
 #'   for \code{moon_reader()}, arguments passed to
 #'   \code{rmarkdown::\link{html_document}()}.
@@ -88,8 +91,13 @@ moon_reader = function(
     '(%s)(%d);', pkg_file('js/countdown.js'), countdown
   )
 
+  titleSlideClass <- if (!is.null(nature[['titleSlideClass']])) paste(
+    nature[['titleSlideClass']], collapse = ", "
+  ) else "center, middle, inverse"
+
   before = nature[['beforeInit']]
-  nature[['countdown']] = nature[['autoplay']] = nature[['beforeInit']] = NULL
+  nature[['countdown']] = nature[['autoplay']] = nature[['beforeInit']] =
+    nature[["titleSlideClass"]] = NULL
 
   write_utf8(as.character(tagList(
     tags$script(src = chakra),
@@ -116,7 +124,8 @@ moon_reader = function(
       if (identical(mathjax, 'default')) {
         mathjax = 'https://cdn.bootcss.com/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML'
       }
-      pandoc_args = c(pandoc_args, '-V', paste0('mathjax-url=', mathjax))
+      pandoc_args = c(pandoc_args, '-V', paste0('mathjax-url=', mathjax),
+                      "-V", paste0('title-slide-class=', titleSlideClass, ''))
       mathjax = NULL
     }
     rmarkdown::html_document(

--- a/inst/rmarkdown/templates/xaringan/resources/default.html
+++ b/inst/rmarkdown/templates/xaringan/resources/default.html
@@ -23,7 +23,7 @@ $endfor$
     <textarea id="source">
 $if(title-slide)$
 $if(title)$
-class: center, middle, inverse, title-slide
+class: $title-slide-class$, title-slide
 
 # $title$
 $if(subtitle)$

--- a/inst/rmarkdown/templates/xaringan/resources/default.html
+++ b/inst/rmarkdown/templates/xaringan/resources/default.html
@@ -23,7 +23,7 @@ $endfor$
     <textarea id="source">
 $if(title-slide)$
 $if(title)$
-class: $title-slide-class$, title-slide
+class: $title-slide-class$
 
 # $title$
 $if(subtitle)$

--- a/inst/rmarkdown/templates/xaringan/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/xaringan/skeleton/skeleton.Rmd
@@ -295,6 +295,31 @@ DT::datatable(
     ```
 
     Then you will see a timer counting down from `01:00`, to `00:59`, `00:58`, ... When the time is out, the timer will continue but the time turns red.
+    
+---
+
+# Some Tips
+
+- The title slide is created automatically by **xaringan**, but it is just another remark.js slide added before your other slides.
+
+    The title slide is set to `class: center, middle, inverse, title-slide` by default. You can change the classes applied to the title slide with the `titleSlideClass` option of `nature` (`title-slide` is always applied).
+
+    ```yaml
+    output:
+      xaringan::moon_reader:
+        nature:
+          titleSlideClass: [top, left, inverse]
+    ```
+    
+--
+
+- If you'd like to create your own title slide, disable **xaringan**'s title slide with the `seal = FALSE` option of `moon_reader`.
+
+    ```yaml
+    output:
+      xaringan::moon_reader:
+        seal: false
+    ```
 
 ---
 

--- a/man/moon_reader.Rd
+++ b/man/moon_reader.Rd
@@ -49,7 +49,10 @@ options provided by remark.js, you can also set \code{autoplay} to a number
 \code{autoplay} milliseconds. You can also set \code{countdown} to a number
 (the number of milliseconds) to include a countdown timer on each slide. If
 using \code{autoplay}, you can optionally set \code{countdown} to
-\code{TRUE} to include a countdown equal to \code{autoplay}.}
+\code{TRUE} to include a countdown equal to \code{autoplay}. To alter the
+set of classes applied to the title slide, you can optionally set
+\code{titleSlideClass} to a vector of classes; the default is
+\code{c("center", "middle", "inverse")}.}
 
 \item{...}{For \code{tsukuyomi()}, arguments passed to \code{moon_reader()};
 for \code{moon_reader()}, arguments passed to


### PR DESCRIPTION
This PR follows up on issue #136 (allowing users to specify the title slide classes from the `nature` argument of `moon_reader`).

- I added a `titleSlideClass` argument to `nature` in `moon_reader` that takes a character vector (or single string) and passes to the associated pandoc argument. I chose camel case for consistency with the other arguments to `nature`.

- I added a `title-slide-class` variable to the `default.html` pandoc template.

- I added a slide to the "Some Tips" section of the xaringan overview slides with instructions on using `titleSlideClass` and also on using `seal = FALSE` to remove the title slide. (Added as a separate commit so you can easily revert if not desired.)

- I updated the roxygen documentation for `moon_reader` in `R/render.R`, but I did not re-generate the docs.

All of the following achieve the same appearance:

```yaml
output:
  xaringan::moon_reader:
    nature:
      titleSlideClass: [top, left]
```

```yaml
output:
  xaringan::moon_reader:
    nature:
      titleSlideClass: "top left"
```

```yaml
output:
  xaringan::moon_reader:
    nature:
      titleSlideClass: 
        - top
        - left
```

![image](https://user-images.githubusercontent.com/5420529/40282271-c7f8c828-5c3a-11e8-9789-440804dc9452.png)
