### PR TITLE
Add setup code for colored code output to templates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
-Package: xaringan
 Type: Package
+Package: xaringan
 Title: Presentation Ninja
 Version: 0.7.1
 Authors@R: c(
@@ -18,16 +18,19 @@ Authors@R: c(
     )
 Description: Create HTML5 slides with R Markdown and the JavaScript library
     'remark.js' (<https://remarkjs.com>).
-Imports:
-    htmltools,
-    knitr (>= 1.16),
-    servr (>= 0.5),
-    xfun (>= 0.2),
-    rmarkdown
-Suggests: rstudioapi, testit
 License: MIT + file LICENSE
 URL: https://github.com/yihui/xaringan
 BugReports: https://github.com/yihui/xaringan/issues
+Imports: 
+    htmltools,
+    knitr (>= 1.16),
+    rmarkdown,
+    servr (>= 0.5),
+    xfun (>= 0.2)
+Suggests: 
+    fansi (>= 0.3),
+    rstudioapi,
+    testit
 VignetteBuilder: knitr
 Encoding: UTF-8
 RoxygenNote: 6.0.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## NEW FEATURES
 
-
+- Colored terminal output (through the `fansi` package) can be enabled by uncommenting two code lines in the setup chunk of the template (#160)
 
 # CHANGES IN xaringan VERSION 0.7
 

--- a/inst/rmarkdown/templates/xaringan/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/xaringan/skeleton/skeleton.Rmd
@@ -14,6 +14,11 @@ output:
 
 ```{r setup, include=FALSE}
 options(htmltools.dir.version = FALSE)
+
+### code output coloring. uncomment to use. 
+### See https://twitter.com/BrodieGaslam/status/1029059002225721344 for a preview
+# old.hooks = fansi::set_knit_hooks(knitr::knit_hooks)
+# options(crayon.enabled = TRUE)
 ```
 
 background-image: url(https://upload.wikimedia.org/wikipedia/commons/b/be/Sharingan_triple.svg)

--- a/inst/rmarkdown/templates/xaringan_zh-CN/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/xaringan_zh-CN/skeleton/skeleton.Rmd
@@ -15,6 +15,11 @@ output:
 
 ```{r setup, include=FALSE}
 options(htmltools.dir.version = FALSE)
+
+### code output coloring. uncomment to use. 
+### See https://twitter.com/BrodieGaslam/status/1029059002225721344 for a preview
+# old.hooks = fansi::set_knit_hooks(knitr::knit_hooks)
+# options(crayon.enabled = TRUE)
 ```
 
 background-image: url(https://upload.wikimedia.org/wikipedia/commons/b/be/Sharingan_triple.svg)


### PR DESCRIPTION
fixes #160 

Tidy DESCRIPTION via `usethis::use_tidy_description()`.