### PR TITLE
Added colons after xaringan::moon_reader in YAML example

### DIFF
--- a/inst/rmarkdown/templates/xaringan/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/xaringan/skeleton/skeleton.Rmd
@@ -123,7 +123,7 @@ Provides an R Markdown output format `xaringan::moon_reader` as a wrapper for re
 ---
 title: "A Cool Presentation"
 output:
-  xaringan::moon_reader
+  xaringan::moon_reader:
     yolo: true
     nature:
       autoplay: 30000


### PR DESCRIPTION
I believe this change is needed for the example code to be correct.