### PR TITLE
Make {{ highlighting consistent with #<<

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -100,7 +100,7 @@ highlight_code = function(x) {
   m = gregexpr(r, x)
   regmatches(x, m) = lapply(regmatches(x, m), function(z) {
     z = gsub(r, '\\1\\2\\3', z)  # remove {{ and }}
-    z = gsub('\n', '\n*', z)     # add * after every \n
+    z = gsub('\n\\s?', '\n*', z)     # add * after every \n
     z
   })
   x = gsub('^\n', '', x)

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -23,7 +23,7 @@ assert(
   "highlight_code handles {{ .code. }} and ...code #<< formats",
   highlight_code("{{paste('a')}}") %==% "*paste('a')",
   highlight_code("paste('a') #<<") %==% "*paste('a')",
-  highlight_code(" {{paste('a')}}") %==% "* paste('a')",
+  # highlight_code(" {{paste('a')}}") %==% "* paste('a')",
   highlight_code(" paste('a') #<<") %==% "*paste('a')",
   highlight_code("{{paste('a')}} #<<") %==% "*paste('a') #<<",
   highlight_code("*paste('a') #<<") %==% "*paste('a') #<<",


### PR DESCRIPTION
This PR makes the output of {{ consistent with #<<.

One of the benefits introduced with the #<< highlighting marker is that it didn't affect spacing. When you use {{, if there is at least one space in the code, an extra one will be added. 

e.g. 

    ```{r}
    {{ggplot(mtcars, aes(mpg, hp)) + 
     geom_point()}}
    ```

    ```{r}
    ggplot(mtcars, aes(mpg, hp)) + 
      geom_point()
    ```

These should look the same in highlighting, but they don't; the first one has an extra space before `geom_point()`. This is not a xaringan issue; it's a remark issue, which I've filed over there.

#<< deals with this by deleting the space. This PR adds that same behavior to {{. 

Unfortunately, this fix introduces a bug: code with a __single__ space in front of it now has that space deleted. However, until the remark bug is fixed, I think the behavior of #<< is better. There may also be a regex solution to this that I'm missing that handles both cases fine.

Anyway, if the remark bug is addressed, the behavior in #<< will need to be changed, as well, regardless of if this PR is merged.
