### PR TITLE
Add highlighting for output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ Authors@R: c(
     person("Sean", "Lopp", role = "ctb"),
     person("Lucy", "D'Agostino McGowan", role = "ctb", comment = c(ORCID = "0000-0001-7297-9359")),
     person("Emi", "Tanaka", role = "ctb"),
-    person("Yongfu", "Liao", role = "ctb")
+    person("Yongfu", "Liao", role = "ctb"),
+    person("Malcolm", "Barrett", role = "ctb", comment = c(ORCID = "0000-0003-0299-5825"))
     )
 Description: Create HTML5 slides with R Markdown and the JavaScript library
     'remark.js' (<https://remarkjs.com>).
@@ -33,4 +34,4 @@ URL: https://github.com/yihui/xaringan
 BugReports: https://github.com/yihui/xaringan/issues
 VignetteBuilder: knitr
 Encoding: UTF-8
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## NEW FEATURES
 
+- Added output highlighting using the chunk option `highlight.output`. (@malcolmbarrett, #175)
+
 - Added a CSS theme `chocolate`. See [here](https://liao961120.github.io/slides/xaringan/) for an example slide. (@liao961120, #171)
 
 - Added a set of CSS theme `kunoichi`, `shinobi` and `ninjutsu` - see [here for example](https://emitanaka.github.io/ninja-theme) (@emitanaka, #165)

--- a/R/render.R
+++ b/R/render.R
@@ -147,9 +147,24 @@ moon_reader = function(
     }
   }
 
+  hook_highlight_output = if (isTRUE(nature$highlightLines)) {
+    # an ugly way to access the `output` hook of markdown output in knitr
+    hook_output = local({
+      ohooks = knitr::knit_hooks$get(); on.exit(knitr::knit_hooks$restore(ohooks))
+      knitr::render_markdown()
+      knitr::knit_hooks$get('output')
+    })
+
+    function(x, options) {
+      res = highlight_output(x, options)
+      hook_output(res, options)
+    }
+  }
+
   rmarkdown::output_format(
     if (!is.null(hook_highlight)) {
-      rmarkdown::knitr_options(knit_hooks = list(source = hook_highlight))
+      rmarkdown::knitr_options(knit_hooks = list(source = hook_highlight,
+                                                 output = hook_highlight_output))
     },
     NULL, clean_supporting = self_contained,
     pre_knit = function(...) {

--- a/R/render.R
+++ b/R/render.R
@@ -133,29 +133,25 @@ moon_reader = function(
   }
 
   optk = list()
+
+  hooks = local({
+    ohooks = knitr::knit_hooks$get(); on.exit(knitr::knit_hooks$restore(ohooks))
+    knitr::render_markdown()
+    knitr::knit_hooks$get(c('source', 'output'))
+  })
+
   hook_highlight = if (isTRUE(nature$highlightLines)) {
     # an ugly way to access the `source` hook of markdown output in knitr
-    hook_source = local({
-      ohooks = knitr::knit_hooks$get(); on.exit(knitr::knit_hooks$restore(ohooks))
-      knitr::render_markdown()
-      knitr::knit_hooks$get('source')
-    })
-
     function(x, options) {
+      hook_source = hooks[['source']]
       res = hook_source(x, options)
       highlight_code(res)
     }
   }
 
   hook_highlight_output = if (isTRUE(nature$highlightLines)) {
-    # an ugly way to access the `output` hook of markdown output in knitr
-    hook_output = local({
-      ohooks = knitr::knit_hooks$get(); on.exit(knitr::knit_hooks$restore(ohooks))
-      knitr::render_markdown()
-      knitr::knit_hooks$get('output')
-    })
-
     function(x, options) {
+      hook_output = hooks[['output']]
       res = highlight_output(x, options)
       hook_output(res, options)
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -111,6 +111,27 @@ highlight_code = function(x) {
   paste(x, collapse = '\n')
 }
 
+highlight_output = function(x, options) {
+  highlight.output = options$highlight.output %||% FALSE
+  if (!is.null(options$highlight.lines)) highlight.output = TRUE
+  if (highlight.output) {
+    x = strsplit(x, '\n')[[1]]
+    highlight.lines = options$highlight.lines %||% seq_along(x)
+    x[highlight.lines] = paste0('*', x[highlight.lines])
+    x = paste(x, collapse = '\n')
+   }
+  x
+}
+
+`%||%` = function(x, y) {
+  if (is.null(x)) {
+      y
+  }
+  else {
+      x
+  }
+}
+
 # make sure blank lines and trailing \n are not removed by strsplit()
 split_lines = function(x) {
   unlist(strsplit(paste0(x, '\n'), '\n'))

--- a/R/utils.R
+++ b/R/utils.R
@@ -112,24 +112,21 @@ highlight_code = function(x) {
 }
 
 highlight_output = function(x, options) {
-  highlight.output = options$highlight.output %||% FALSE
-  if (!is.null(options$highlight.lines)) highlight.output = TRUE
-  if (highlight.output) {
-    x = strsplit(x, '\n')[[1]]
-    highlight.lines = options$highlight.lines %||% seq_along(x)
-    x[highlight.lines] = paste0('*', x[highlight.lines])
-    x = paste(x, collapse = '\n')
-   }
-  x
-}
+  highlight.output = options$highlight.output
+  if (is.null(highlight.output)) return(x)
+  if (is.logical(highlight.output) & !highlight.output) return(x)
+  x = strsplit(x, '\n')[[1]]
 
-`%||%` = function(x, y) {
-  if (is.null(x)) {
-      y
+  if (isTRUE(highlight.output)) {
+     highlight.lines = seq_along(x)
+  } else if (is.numeric(highlight.output)) {
+    highlight.lines = highlight.output
+  } else {
+    stop("`highlight.output` must be numeric or logical")
   }
-  else {
-      x
-  }
+
+  x[highlight.lines] = paste0('*', x[highlight.lines])
+  paste(x, collapse = '\n')
 }
 
 # make sure blank lines and trailing \n are not removed by strsplit()


### PR DESCRIPTION
This PR adds a chunk hook for highlighting R output. It essentially adds two chunk options, `highlight.output` and `highlight.lines`. `highlight.output = TRUE` will highlight all outputted lines, while `highlight.lines` takes a vector of line numbers and highlights those lines, e.g. `highlight.lines = 5:8`.

Here are some examples

## Highlight all output

![](https://i.imgur.com/p9SxJUU.png)
![](https://i.imgur.com/Ye5mw1C.png)

## Highlight specific lines

![](https://i.imgur.com/su7Qk3n.png)
![](https://i.imgur.com/3S8G9bb.png)

## Highlighting with other output

![](https://i.imgur.com/gGVaSmx.png)
![](https://i.imgur.com/fm3GiG1.png)