### PR TITLE
fix typo in version number

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: xaringan
 Type: Package
 Title: Presentation Ninja
-Version: 0.8
+Version: 0.8.9
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Benjie", "Gillam", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: xaringan
 Type: Package
 Title: Presentation Ninja
-Version: 0.8.
+Version: 0.8
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Benjie", "Gillam", role = "ctb"),


### PR DESCRIPTION
when installing the package I currently get:

```
Downloading GitHub repo yihui/xaringan@master
✔  checking for file ‘/tmp/RtmpM0LCI1/remotes436466f2bc88/yihui-xaringan-b520b7b/DESCRIPTION’
─  preparing ‘xaringan’:
E  checking DESCRIPTION meta-information
   Malformed package version.
   
   See section 'The DESCRIPTION file' in the 'Writing R Extensions'
   manual.
```