### PR TITLE
Add hidden cloud CSS theme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 
 ## NEW FEATURES
 
+- Added a CSS theme `hiddencloud` (@malcolmbarrett, #210)
 - Added the ability to specify an `institute` in the YAML header that is automatically added to the title slide (@paullemmens, #200).
 
 ## BUG FIXES

--- a/inst/rmarkdown/templates/xaringan/resources/hiddencloud.css
+++ b/inst/rmarkdown/templates/xaringan/resources/hiddencloud.css
@@ -1,0 +1,14 @@
+.hiddencloud .remark-code-line-highlighted {
+  background-color:transparent;
+  color: #000 !important;
+  font-weight: bold;
+}
+
+.hiddencloud .remark-code-line {
+  color: #E5E5E5;
+}
+
+.hljs-github .hljs-number, .hljs-github .hljs-keyword, .hljs-github .hljs-literal, .hljs-github .hljs-variable, .hljs-github .hljs-template-variable, .hljs-github .hljs-tag .hljs-attr {
+  color: #E5E5E5;
+}
+


### PR DESCRIPTION
This PR adds a small theme called `hiddencloud` that allows the ability to highlight by greying out non-highlighted text and bolding the highlighted text. I saw this approach used in a recent (non-xaringan) presentation and thought it worked very well.

Adding `class: hiddencloud` to the slide will grey out the code and change the highlighter as described.

Example Rmd code: https://gist.github.com/malcolmbarrett/97315963a2ee56e4df21286b265a4399

Screenshots:
![](https://i.imgur.com/dGPw72s.png)
![](https://i.imgur.com/s3lU3iW.png)