### PR TITLE
Add remark-code-has-line-highlighted class to pre parents of highlighted lines

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -93,7 +93,7 @@ moon_reader = function(
   )
 
   hl_pre_js = if (isTRUE(nature$highlightLines))
-    pkg_file("js/highlight-pre-parent.js") else ""
+    pkg_file('js/highlight-pre-parent.js')
 
   if (is.null(title_cls <- nature[['titleSlideClass']]))
     title_cls = c('center', 'middle', 'inverse')

--- a/R/render.R
+++ b/R/render.R
@@ -92,6 +92,9 @@ moon_reader = function(
     '(%s)(%d);', pkg_file('js/countdown.js'), countdown
   )
 
+  hl_pre_js = if (isTRUE(nature$highlightLines))
+    pkg_file("js/highlight-pre-parent.js") else ""
+
   if (is.null(title_cls <- nature[['titleSlideClass']]))
     title_cls = c('center', 'middle', 'inverse')
   title_cls = paste(c(title_cls, 'title-slide'), collapse = ', ')
@@ -110,7 +113,7 @@ moon_reader = function(
     tags$script(HTML(paste(c(sprintf(
       'var slideshow = remark.create(%s);', if (length(nature)) xfun::tojson(nature) else ''
     ), pkg_file(c('js/show-widgets.js', 'js/print-css.js', 'js/after.js')),
-    play_js, countdown_js), collapse = '\n')))
+    play_js, countdown_js, hl_pre_js), collapse = '\n')))
   )), tmp_js)
 
   html_document2 = function(

--- a/inst/rmarkdown/templates/xaringan/resources/js/highlight-pre-parent.js
+++ b/inst/rmarkdown/templates/xaringan/resources/js/highlight-pre-parent.js
@@ -13,5 +13,5 @@
     let pre = findPreParent(line);
     if (pre && !preParents.includes(pre)) preParents.push(pre);
   }
-  preParents.forEach(p => p.classList += " remark-code-has-line-highlighted");
+  preParents.forEach(p => p.classList.add("remark-code-has-line-highlighted"));
 })(document);

--- a/inst/rmarkdown/templates/xaringan/resources/js/highlight-pre-parent.js
+++ b/inst/rmarkdown/templates/xaringan/resources/js/highlight-pre-parent.js
@@ -1,0 +1,21 @@
+// adds .remark-code-has-line-highlighted class to <pre> parent elements
+// of code chunks containing highlighted lines with class .remark-code-line-highlighted
+(function(d) {
+  const hlines = d.querySelectorAll('.remark-code-line-highlighted');
+  const preParents = [];
+  const findPreParent = function(line, p = 0) {
+    if (p > 1) return null; // traverse up no further than grandparent
+    const el = line.parentElement;
+    if (el.tagName === "PRE") {
+      return el;
+    } else {
+      return findPreParent(el, ++p);
+    }
+  };
+
+  for (let line of hlines) {
+    let pre = findPreParent(line);
+    if (pre && !preParents.includes(pre)) preParents.push(pre);
+  }
+  preParents.forEach(p => p.classList += " remark-code-has-line-highlighted");
+})(document);

--- a/inst/rmarkdown/templates/xaringan/resources/js/highlight-pre-parent.js
+++ b/inst/rmarkdown/templates/xaringan/resources/js/highlight-pre-parent.js
@@ -6,11 +6,7 @@
   const findPreParent = function(line, p = 0) {
     if (p > 1) return null; // traverse up no further than grandparent
     const el = line.parentElement;
-    if (el.tagName === "PRE") {
-      return el;
-    } else {
-      return findPreParent(el, ++p);
-    }
+    return el.tagName === "PRE" ? el : findPreParent(el, ++p);
   };
 
   for (let line of hlines) {


### PR DESCRIPTION
This PR adds a small amount of JS to add the class `.remark-code-has-line-highlighted` to the `<pre>` parent element of highlighted lines (which have the `.remark-code-line-highlighted` class).

This allows users to write CSS that targets code blocks containing highlighted lines, enabling effects such as the one proposed by @malcolmbarrett in #210. I've also created a [small demo here](https://gadenbuie.github.io/xaringan-line-focus).

I wasn't completely sure of the desired mechanism for including the JS file, but I followed a similar pattern to that used by the autoplay and countdown scripts and the required JS is only included when `isTRUE(nature$highlightLines)`. I'd be happy to reconfigure as needed.