### PR TITLE
Some fixes for metropolis theme

### DIFF
--- a/inst/rmarkdown/templates/xaringan/resources/metropolis.css
+++ b/inst/rmarkdown/templates/xaringan/resources/metropolis.css
@@ -16,20 +16,11 @@
   text-shadow: none;
 }
 
-.remark-slide-content > h1 {
-  font-family: 'Fira Sans';
-  font-weight: normal;
-  font-size: 45px;
-  margin-top: -95px;
-  margin-left: -00px;
-  color: #FAFAFA;
-}
-
-.remark-slide-content > inverse {
-width: 112px;
-height: 47px;
-border-bottom: 1px solid black;
-position: absolute;
+inverse {
+  width: 112px;
+  height: 47px;
+  border-bottom: 1px solid black;
+  position: absolute;
 }
 
 /* Removes colored bar from top of the slide resulting in a clear slide */
@@ -37,7 +28,14 @@ position: absolute;
   border-top: 0px solid #FAFAFA;
 }
 
-.remark-slide-content > h2, h3, h4 {
+h1 {
+  font-weight: normal;
+  margin-top: -95px;
+  margin-left: -00px;
+  color: #FAFAFA;
+}
+
+h2, h3, h4 {
   padding-top: -15px;
   padding-bottom: 00px;
   color: #1A292C;
@@ -48,13 +46,24 @@ position: absolute;
   margin-bottom: -10px;
 }
 
-.remark-slide-content > h2, .pull-left > h2, .pull-right > h2 {
+.remark-slide-content h1 {
+  font-size: 45px;
+}
+
+.remark-slide-content h2 {
   font-size: 35px;
 }
 
-.remark-slide-content > h3, .remark-slide-content > h4,
-.pull-left > h3, .pull-left > h4, .pull-right > h3, .pull-right > h4 {
+.remark-slide-content h3 {
   font-size: 30px;
+}
+
+.left-column h2, .left-column h3, .left-column h4 {
+  color: #777;
+}
+
+.left-column h2:last-of-type, .left-column h3:last-child {
+  color: #1A292C;
 }
 
 .title-slide {
@@ -62,7 +71,7 @@ position: absolute;
   border-top: 80px solid #FAFAFA;
 }
 
-.title-slide > h1  {
+.title-slide h1  {
   color: #1A292C;
   font-size: 40px;
   text-shadow: none;
@@ -71,7 +80,7 @@ position: absolute;
   margin-left: 15px;
   padding-top: 80px;
 }
-.title-slide > h2  {
+.title-slide h2  {
   margin-top: -25px;
   padding-bottom: -20px;
   color: #1A292C;
@@ -81,7 +90,7 @@ position: absolute;
   text-align: left;
   margin-left: 15px;
 }
-.title-slide > h3  {
+.title-slide h3  {
   color: #1A292C;
   text-shadow: none;
   font-weight: 300;
@@ -93,13 +102,11 @@ position: absolute;
 
 .remark-slide-number {
   font-size: 13pt;
-  font-family: 'Fira Sans';
   color: #272822;
   opacity: 1;
 }
 .inverse .remark-slide-number {
   font-size: 13pt;
-  font-family: 'Fira Sans';
   color: #FAFAFA;
   opacity: 1;
 }


### PR DESCRIPTION
This PR fixes some issues with titles in the metropolis theme. Particularly, it

- fixes titles to look the same everywhere (they looked different, e.g., under a `.left-column`);
- adds support to gray out non-interactive h2 and h3 titles in a `.left-column`;
- removes some useless qualifiers.