### PR TITLE
pin remark.js version to v0.14

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # CHANGES IN xaringan VERSION 0.15
 
+## BUG FIXES
+
+- Pinned the remark.js version to v0.14 to until upstream support for the latest release is available
+
 ## MINOR CHANGES
 
 - Small tweaks to the Karolinska Institutet theme (thanks, ellessenne, #244).

--- a/R/render.R
+++ b/R/render.R
@@ -71,7 +71,7 @@
 #' # rmarkdown::render('foo.Rmd', 'xaringan::moon_reader')
 moon_reader = function(
   css = c('default', 'default-fonts'), self_contained = FALSE, seal = TRUE, yolo = FALSE,
-  chakra = 'https://remarkjs.com/downloads/remark-latest.min.js', nature = list(),
+  chakra = 'https://cdnjs.cloudflare.com/ajax/libs/remark/0.14.0/remark.min.js', nature = list(),
   ...
 ) {
   theme = grep('[.]css$', css, value = TRUE, invert = TRUE)

--- a/man/decktape.Rd
+++ b/man/decktape.Rd
@@ -48,8 +48,7 @@ For some operating systems you may need to
 }
 \examples{
 if (interactive()) {
-    xaringan::decktape("https://slides.yihui.org/xaringan", "xaringan.pdf", 
-        docker = FALSE)
+  xaringan::decktape('https://slides.yihui.org/xaringan', 'xaringan.pdf', docker = FALSE)
 }
 }
 \references{

--- a/man/moon_reader.Rd
+++ b/man/moon_reader.Rd
@@ -10,7 +10,7 @@ moon_reader(
   self_contained = FALSE,
   seal = TRUE,
   yolo = FALSE,
-  chakra = "https://remarkjs.com/downloads/remark-latest.min.js",
+  chakra = "https://cdnjs.cloudflare.com/ajax/libs/remark/0.14.0/remark.min.js",
   nature = list(),
   ...
 )


### PR DESCRIPTION
To revert temporarily back to the old version of remark.js (prior to 0.15.0) in order to fix issue #245 

If we decide to go forward with this PR I suggest putting in a milestone so we remember to update the reference such that it points to the most recent version of remark.js once that has stabilized again with the new maintainer.

To contribute to this repo, please make sure to:

- [X] Sign the CLA http://www.clahub.com/agreements/yihui/xaringan (if you haven't signed it before).
- [ ] Add a news item to NEWS.md and your name to DESCRIPTION (by alphabetical order) unless you have already been listed there.
- [ ] Provide a URL to a live example (and even better, a couple of screenshots) if you are contributing a new theme.

Thank you!
