### PR TITLE
Fix infinite_moon_reader rendering of parameterized reports (#253)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: xaringan
 Type: Package
 Title: Presentation Ninja
-Version: 0.14.0.9001
+Version: 0.14.9000
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     # contributors ordered alphabetically below

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Authors@R: c(
     person("Joseph", "Casillas", role = "ctb"),
     person("Lucy", "D'Agostino McGowan", role = "ctb", comment = c(ORCID = "0000-0001-7297-9359")),
     person("Malcolm", "Barrett", role = "ctb", comment = c(ORCID = "0000-0003-0299-5825")),
+    person(c("Matthew", "Mark"), "Strasiotto", role = "ctb", comment = c(github = "mstr3336")),
     person("Michael Wayne", "Kearney", role = "ctb"),
     person("Nan-Hung", "Hsieh", role = "ctb"),
     person("Ole Petter", "Bang", role = "ctb", comment = "CSS in rmarkdown/templates/xaringan/resources/default.css"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: xaringan
 Type: Package
 Title: Presentation Ninja
-Version: 0.14
+Version: 0.14.0.9001
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     # contributors ordered alphabetically below

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## BUG FIXES
 
 - Pinned the remark.js version to v0.14 until upstream support for the latest release is available
+- Fixed bug with parameterized reports and `infinite_moon_reader()` where `rmarkdown::render()` would throw an error about `params` being in the environment, due to the `params` argument being defined in the calling scope ( `infinite_moon_reader()` ). (thanks @mstr3336, #253)
 
 ## MINOR CHANGES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,9 @@
 
 - Pinned the remark.js version to v0.14 until upstream support for the latest release is available
 
-- `infinite_moon_reader()` now accepts additional arguments via `...` that are passed to `rmarkdown::render()`. This improves the addition of the `params` argument in `infinite_moon_reader()` in version 0.14 and allows users to over-ride parameters defined in the top-level YAML in the slides at run time. It also lets users set rendering options, such as `quiet = TRUE` or setting `output_file`. (thanks @mstr3336, @gadenbuie, #253)
+- `infinite_moon_reader()` now accepts additional arguments via `...` that are passed to `rmarkdown::render()`. 
+  This improves the addition of the `params` argument in `infinite_moon_reader()` in version 0.14 and allows users to over-ride parameters defined in the top-level YAML in the slides at run time.
+  It also lets users set rendering options, such as `quiet = TRUE` or setting `output_file`. (thanks @mstr3336, @gadenbuie, #253)
 
 ## MINOR CHANGES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@
 ## BUG FIXES
 
 - Pinned the remark.js version to v0.14 until upstream support for the latest release is available
-- Fixed bug with parameterized reports and `infinite_moon_reader()` where `rmarkdown::render()` would throw an error about `params` being in the environment, due to the `params` argument being defined in the calling scope ( `infinite_moon_reader()` ). (thanks @mstr3336, #253)
+
+- `infinite_moon_reader()` now accepts additional arguments via `...` that are passed to `rmarkdown::render()`. This improves the addition of the `params` argument in `infinite_moon_reader()` in version 0.14 and allows users to over-ride parameters defined in the top-level YAML in the slides at run time. It also lets users set rendering options, such as `quiet = TRUE` or setting `output_file`. (thanks @mstr3336, @gadenbuie, #253)
 
 ## MINOR CHANGES
 

--- a/R/render.R
+++ b/R/render.R
@@ -210,7 +210,7 @@ tsukuyomi = function(...) moon_reader(...)
 #' @param moon The input Rmd file path (if missing and in RStudio, the current
 #'   active document is used).
 #' @param cast_from The root directory of the server.
-#' @param params Passed to \code{rmarkdown::\link[rmarkdown]{render}()}.
+#' @param ... Passed to \code{rmarkdown::\link[rmarkdown]{render}()}.
 #' @references \url{http://naruto.wikia.com/wiki/Infinite_Tsukuyomi}
 #' @note This function is not really tied to the output format
 #'   \code{\link{moon_reader}()}. You can use it to serve any single-HTML-file R
@@ -218,9 +218,7 @@ tsukuyomi = function(...) moon_reader(...)
 #' @seealso \code{servr::\link{httw}}
 #' @export
 #' @rdname inf_mr
-infinite_moon_reader = function(moon, cast_from = '.', params = NULL) {
-  parameters <- params
-  rm(params)
+infinite_moon_reader = function(moon, cast_from = '.', ...) {
   # when this function is called via the RStudio addin, use the dir of the
   # current active document
   if (missing(moon) && requireNamespace('rstudioapi', quietly = TRUE)) {
@@ -233,9 +231,10 @@ infinite_moon_reader = function(moon, cast_from = '.', params = NULL) {
     )
   }
   moon = normalize_path(moon)
-  rebuild = function() {
-    rmarkdown::render(moon, envir = parent.frame(2), params = parameters)
-  }
+  dots = list(...)
+  dots$envir = parent.frame()
+  dots$input = moon
+  rebuild = function() do.call(rmarkdown::render, dots)
   html = NULL
   # rebuild if moon or any dependencies (CSS/JS/images) have been updated
   build = local({

--- a/R/render.R
+++ b/R/render.R
@@ -219,6 +219,8 @@ tsukuyomi = function(...) moon_reader(...)
 #' @export
 #' @rdname inf_mr
 infinite_moon_reader = function(moon, cast_from = '.', params = NULL) {
+  parameters <- params
+  rm(params)
   # when this function is called via the RStudio addin, use the dir of the
   # current active document
   if (missing(moon) && requireNamespace('rstudioapi', quietly = TRUE)) {
@@ -232,7 +234,7 @@ infinite_moon_reader = function(moon, cast_from = '.', params = NULL) {
   }
   moon = normalize_path(moon)
   rebuild = function() {
-    rmarkdown::render(moon, envir = parent.frame(2), params = params)
+    rmarkdown::render(moon, envir = parent.frame(2), params = parameters)
   }
   html = NULL
   # rebuild if moon or any dependencies (CSS/JS/images) have been updated

--- a/man/inf_mr.Rd
+++ b/man/inf_mr.Rd
@@ -5,9 +5,9 @@
 \alias{inf_mr}
 \title{Serve and live reload slides}
 \usage{
-infinite_moon_reader(moon, cast_from = ".", params = NULL)
+infinite_moon_reader(moon, cast_from = ".", ...)
 
-inf_mr(moon, cast_from = ".", params = NULL)
+inf_mr(moon, cast_from = ".", ...)
 }
 \arguments{
 \item{moon}{The input Rmd file path (if missing and in RStudio, the current
@@ -15,7 +15,7 @@ active document is used).}
 
 \item{cast_from}{The root directory of the server.}
 
-\item{params}{Passed to \code{rmarkdown::\link[rmarkdown]{render}()}.}
+\item{...}{Passed to \code{rmarkdown::\link[rmarkdown]{render}()}.}
 }
 \description{
 Use the \pkg{servr} package to serve and reload slides on change.

--- a/tests/testit/parameterized.Rmd
+++ b/tests/testit/parameterized.Rmd
@@ -1,0 +1,18 @@
+---
+title: "Issue #253"
+subtitle: "https://github.com/yihui/xaringan/issues/253"
+params:
+  foo: oof
+  bar: rab
+  baz: zab
+output:
+  xaringan::moon_reader:
+    lib_dir: libs
+    seal: false
+---
+
+```{r display, echo=FALSE, results="asis"}
+for (nm in names(params)) {
+  cat("\n\nparams$", nm, " = ", params[[nm]], sep = "")
+}
+```

--- a/tests/testit/test-render.R
+++ b/tests/testit/test-render.R
@@ -1,0 +1,41 @@
+library(testit)
+
+tmpin = tempfile(fileext = ".Rmd")
+file.copy("parameterized.Rmd", tmpin)
+tmpout = tempfile(fileext = ".html")
+tmpout_file = basename(tmpout)
+
+options(servr.daemon = TRUE)
+s = xaringan::inf_mr(tmpin,
+                     cast_from = dirname(tmpout),
+                     output_file = tmpout_file,
+                     quiet = TRUE)
+s$stop_server()
+params_top_level = readLines(tmpout)
+
+count_matches = function(pattern, text) sum(grepl(pattern, text, fixed = TRUE))
+
+assert('parameterized slides uses top-level `params` in YAML', {
+  (count_matches("params$foo = oof", params_top_level) %==% 1L)
+  (count_matches("params$bar = rab", params_top_level) %==% 1L)
+  (count_matches("params$baz = zab", params_top_level) %==% 1L)
+})
+
+s = xaringan::inf_mr(tmpin,
+                     cast_from = dirname(tmpout),
+                     params = list(foo = "hello", bar = "world"),
+                     output_file = tmpout_file,
+                     quiet = TRUE)
+s$stop_server()
+params_top_level = readLines(tmpout)
+
+assert('inf_mr(...) overrides `params` in YAML', {
+  (count_matches("params$foo = oof", params_top_level) %==% 0L)
+  (count_matches("params$foo = hello", params_top_level) %==% 1L)
+  (count_matches("params$bar = rab", params_top_level) %==% 0L)
+  (count_matches("params$bar = world", params_top_level) %==% 1L)
+})
+
+assert('inf_mr(...) params falls back to top-level `params` in YAML', {
+  (count_matches("params$baz = zab", params_top_level) %==% 1L)
+})


### PR DESCRIPTION
# Prework

- [x] Sign the CLA http://www.clahub.com/agreements/yihui/xaringan (if you haven't signed it before).
- [x] Add a news item to NEWS.md and your name to DESCRIPTION (by alphabetical order) unless you have already been listed there.
- [ ] ~Provide a URL to a live example (and even better, a couple of screenshots) if you are contributing a new theme.~

# Details

Resolves #253 - `inf_mr` and friends were failing on reports that had `params` as an argument in the front-matter. 

This was due to the object `params` being defined in the scope of `infinite_moon_reader`, which enclosed a call to `rmarkdown::render`. `rmarkdown::render` doesn't like it when there is a `params` object in the enclosing environment.

The following document now renders:

````pandoc
---
title: "Params Error"
subtitle: "Makes me sad"
author: "mstr3336"
institute: "mstr3336"
date: "`r Sys.Date()`"
params:
  foo: oof
  bar: rab
  baz: zab
output:
  xaringan::moon_reader:
    lib_dir: libs
    nature:
      highlightStyle: github
      highlightLines: true
      countIncrementalSlides: false
---


```{r setup, include=FALSE}
options(htmltools.dir.version = FALSE)
```

```{r display}
for (nm in names(params)) {
  print(paste0("params$", nm, " -> ", params[[nm]]))
}
```

---

````

## Rendering:
```r
xaringan::inf_mr(moon = "./param_error_xaringan.Rmd")
```


```
processing file: param_error_xaringan.Rmd
  |..................                                                                        |  20%
   inline R code fragments

  |....................................                                                      |  40%
label: setup (with options) 
List of 1
 $ include: logi FALSE

  |......................................................                                    |  60%
  ordinary text without R code

  |........................................................................                  |  80%
label: display
  |..........................................................................................| 100%
  ordinary text without R code


output file: param_error_xaringan.knit.md

/Applications/RStudio.app/Contents/MacOS/pandoc/pandoc +RTS -K512m -RTS param_error_xaringan.utf8.md --to html4 --from markdown+autolink_bare_uris+tex_math_single_backslash --output param_error_xaringan.html --smart --email-obfuscation none -V 'mathjax-url=https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-MML-AM_CHTML' -V 'title-slide-class=center, middle, inverse, title-slide' --standalone --section-divs --template /Users/matthew/xaringan_reprex/renv/library/R-3.6/x86_64-apple-darwin15.6.0/xaringan/rmarkdown/templates/xaringan/resources/default.html --no-highlight --include-in-header /var/folders/sn/jqrwf4ls0cj7f9jml4b3yjt00000gn/T//RtmpDuK53o/rmarkdown-str99566ccdb53b.html --include-before-body /var/folders/sn/jqrwf4ls0cj7f9jml4b3yjt00000gn/T//RtmpDuK53o/xaringan9956318cff52.md --include-after-body /var/folders/sn/jqrwf4ls0cj7f9jml4b3yjt00000gn/T//RtmpDuK53o/xaringan995652d35951.js --variable title-slide=true --variable math=true 

Output created: param_error_xaringan.html
To stop the server, run servr::daemon_stop(1) or restart your R session
Serving the directory /Users/matthew/xaringan_reprex at http://127.0.0.1:4321/param_error_xaringan.html
```
<details><summary>Session Info</summary>

```r
xfun::session_info("xaringan")
```

```
R version 3.6.2 Patched (2020-01-12 r77656)
Platform: x86_64-apple-darwin15.6.0 (64-bit)
Running under: macOS Mojave 10.14.6, RStudio 1.1.463

Locale: en_AU.UTF-8 / en_AU.UTF-8 / en_AU.UTF-8 / C / en_AU.UTF-8 / en_AU.UTF-8

Package version:
  base64enc_0.1.3      BH_1.72.0.3          digest_0.6.25       
  evaluate_0.14        glue_1.3.1           graphics_3.6.2      
  grDevices_3.6.2      highr_0.8            htmltools_0.4.0     
  httpuv_1.5.2         jsonlite_1.6.1       knitr_1.28.2        
  later_1.0.0          magrittr_1.5         markdown_1.1        
  methods_3.6.2        mime_0.9             promises_1.1.0      
  R6_2.4.1             Rcpp_1.0.3           rlang_0.4.4         
  rmarkdown_2.1.1      servr_0.15           stats_3.6.2         
  stringi_1.4.6        stringr_1.4.0        tinytex_0.20        
  tools_3.6.2          utils_3.6.2          xaringan_0.14.0.9001
  xfun_0.12            yaml_2.2.1  
```

</details>

The broken behaviour is described in #253