### PR TITLE
put back the correct version numbering

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: xaringan
 Type: Package
 Title: Presentation Ninja
-Version: 0.14.9000
+Version: 0.14.1
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     # contributors ordered alphabetically below


### PR DESCRIPTION
following changes in #254. 
We don't use .9000 convention in this repository

See https://github.com/yihui/xaringan/commit/71b0b39d617c4d230882cfe60c32dd7f8aa63a3e and https://github.com/yihui/xaringan/commit/85c0e7f268ba94306bb33f2cfb70ad846d03b9ad

To contribute to this repo, please make sure to:

- [x] Sign the CLA http://www.clahub.com/agreements/yihui/xaringan (if you haven't signed it before).
- [x] Add a news item to NEWS.md and your name to DESCRIPTION (by alphabetical order) unless you have already been listed there.
- [x] Provide a URL to a live example (and even better, a couple of screenshots) if you are contributing a new theme.

Thank you!
