### PR TITLE
Script tags in slides

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
     person("Daniel", "Anderson", role = "ctb"),
     person("Dawei", "Lang", role = "ctb"),
     person("Emi", "Tanaka", role = "ctb"),
-    person("Garrick", "Aden-Buie", role = "ctb"),
+    person("Garrick", "Aden-Buie", role = "ctb", comment = c(ORCID = "0000-0002-7111-0077")),
     person("Iñaki", "Ucar", role = "ctb", comment = c(ORCID = "0000-0001-6403-5550")),
     person("John", "Little", role = "ctb"),
     person("Joseph", "Casillas", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 - `infinite_moon_reader()` now accepts additional arguments via `...` that are passed to `rmarkdown::render()`. This improves the addition of the `params` argument in `infinite_moon_reader()` in version 0.14 and allows users to over-ride parameters defined in the top-level YAML in the slides at run time. It also lets users set rendering options, such as `quiet = TRUE` or setting `output_file` (thanks @mstr3336, @gadenbuie, #253).
 
-- Inline `<script>` tags and JavaScript code chunks in the R Markdown source now run in the browser with xaringan. `<script>` tags included in the slides area are moved to the end of `<body>` and are run after the remarkjs `slideshow` has been initialized (thanks @gadenbuie, #256).
+- Inline `<script>` tags and JavaScript code chunks in the R Markdown source now run in the browser with **xaringan** (thanks @gadenbuie, #256).
 
 ## MINOR CHANGES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - `infinite_moon_reader()` now accepts additional arguments via `...` that are passed to `rmarkdown::render()`. This improves the addition of the `params` argument in `infinite_moon_reader()` in version 0.14 and allows users to over-ride parameters defined in the top-level YAML in the slides at run time. It also lets users set rendering options, such as `quiet = TRUE` or setting `output_file` (thanks @mstr3336, @gadenbuie, #253).
 
+- Inline `<script>` tags and JavaScript code chunks in the R Markdown source now run in the browser with xaringan. `<script>` tags included in the slides area are moved to the end of `<body>` and are run after the remarkjs `slideshow` has been initialized (thanks @gadenbuie, #256).
+
 ## MINOR CHANGES
 
 - Small tweaks to the Karolinska Institutet theme (thanks, ellessenne, #244).

--- a/R/render.R
+++ b/R/render.R
@@ -116,7 +116,7 @@ moon_reader = function(
     },
     tags$script(HTML(paste(c(sprintf(
       'var slideshow = remark.create(%s);', if (length(nature)) xfun::tojson(nature) else ''
-    ), pkg_file(c('js/show-widgets.js', 'js/print-css.js', 'js/after.js')),
+    ), pkg_file(c('js/show-widgets.js', 'js/print-css.js', 'js/after.js', 'js/script-tags.js')),
     play_js, countdown_js, hl_pre_js), collapse = '\n')))
   )), tmp_js)
 

--- a/inst/rmarkdown/templates/xaringan/resources/js/script-tags.js
+++ b/inst/rmarkdown/templates/xaringan/resources/js/script-tags.js
@@ -11,19 +11,10 @@
     '.remark-slides-area .remark-slide-container:not(.has-continuation) script'
   );
   if (!scripts.length) return;
-  document.body.appendChild(
-    document.createComment('scripts moved from inside remark slide source')
-  );
   for (var i = 0; i < scripts.length; i++) {
     var s = document.createElement('script');
     var code = document.createTextNode(scripts[i].textContent);
     s.appendChild(code);
-    document.body.appendChild(s);
-  }
-  var all_scripts = document.querySelectorAll('.remark-slides-area script');
-  for (var i = 0; i < all_scripts.length; i++) {
-    // remove original <script> tags and leave a note
-    var note = document.createComment('script moved to end of document body by xaringan');
-    all_scripts[i].parentElement.replaceChild(note, all_scripts[i]);
+    scripts[i].parentElement.replaceChild(s, scripts[i]);
   }
 })();

--- a/inst/rmarkdown/templates/xaringan/resources/js/script-tags.js
+++ b/inst/rmarkdown/templates/xaringan/resources/js/script-tags.js
@@ -1,0 +1,29 @@
+(function() {
+  "use strict"
+  /* Move <script> tags from slides to end of document
+   *
+   * Runs after post-processing of markdown source into slides and moves only
+   * <script>s on the last slide of continued slides using the .has-continuation
+   * class added by xaringan. Finally, all <script>s in the slides area are
+   * removed with a note that they can be found at the end of <body>.
+   */
+  var scripts = document.querySelectorAll(
+    '.remark-slides-area .remark-slide-container:not(.has-continuation) script'
+  );
+  if (!scripts.length) return;
+  document.body.appendChild(
+    document.createComment('scripts moved from inside remark slide source')
+  );
+  for (var i = 0; i < scripts.length; i++) {
+    var s = document.createElement('script');
+    var code = document.createTextNode(scripts[i].textContent);
+    s.appendChild(code);
+    document.body.appendChild(s);
+  }
+  var all_scripts = document.querySelectorAll('.remark-slides-area script');
+  for (var i = 0; i < all_scripts.length; i++) {
+    // remove original <script> tags and leave a note
+    var note = document.createComment('script moved to end of document body by xaringan');
+    all_scripts[i].parentElement.replaceChild(note, all_scripts[i]);
+  }
+})();

--- a/inst/rmarkdown/templates/xaringan/resources/js/script-tags.js
+++ b/inst/rmarkdown/templates/xaringan/resources/js/script-tags.js
@@ -1,11 +1,11 @@
 (function() {
   "use strict"
-  /* Move <script> tags from slides to end of document
+  /* Replace <script> tags in slides area to make them executable
    *
-   * Runs after post-processing of markdown source into slides and moves only
+   * Runs after post-processing of markdown source into slides and replaces only
    * <script>s on the last slide of continued slides using the .has-continuation
-   * class added by xaringan. Finally, all <script>s in the slides area are
-   * removed with a note that they can be found at the end of <body>.
+   * class added by xaringan. Finally, any <script>s in the slides area that
+   * aren't executed are commented out.
    */
   var scripts = document.querySelectorAll(
     '.remark-slides-area .remark-slide-container:not(.has-continuation) script'
@@ -16,5 +16,13 @@
     var code = document.createTextNode(scripts[i].textContent);
     s.appendChild(code);
     scripts[i].parentElement.replaceChild(s, scripts[i]);
+  }
+  var scriptsNotExecuted = document.querySelectorAll(
+    '.remark-slides-area .remark-slide-container.has-continuation script'
+  );
+  if (!scriptsNotExecuted.length) return;
+  for (var i = 0; i < scriptsNotExecuted.length; i++) {
+    var comment = document.createComment(scriptsNotExecuted[i].outerHTML)
+    scriptsNotExecuted[i].parentElement.replaceChild(comment, scriptsNotExecuted[i])
   }
 })();


### PR DESCRIPTION
A better implementation of the idea in #239, this time moving the `<script>` tags in the browser.

- Only `<scripts>` that are children of `.remark-slides-area` and are not a continuation (`:not(.has-continuation)`) are moved.
- All scripts in `.remark-slides-area` are replaced with a comment that they can be found at the end of `<body>`
