### PR TITLE
Ensure attributes are copied to replaced script tags

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN xaringan VERSION 0.16
 
+## BUG FIXES
+
+- Fixed a bug introduced in #256 that caused htmlwidgets not to render (@gadenbuie #258, thanks @eniso-partners #257).
 
 # CHANGES IN xaringan VERSION 0.15
 

--- a/inst/rmarkdown/templates/xaringan/resources/js/script-tags.js
+++ b/inst/rmarkdown/templates/xaringan/resources/js/script-tags.js
@@ -15,6 +15,10 @@
     var s = document.createElement('script');
     var code = document.createTextNode(scripts[i].textContent);
     s.appendChild(code);
+    var scriptAttrs = scripts[i].attributes
+    for (var j = 0; j < scriptAttrs.length; j++) {
+      s.setAttribute(scriptAttrs[j].name, scriptAttrs[j].value)
+    }
     scripts[i].parentElement.replaceChild(s, scripts[i]);
   }
   var scriptsNotExecuted = document.querySelectorAll(

--- a/inst/rmarkdown/templates/xaringan/resources/js/script-tags.js
+++ b/inst/rmarkdown/templates/xaringan/resources/js/script-tags.js
@@ -9,9 +9,9 @@
     var s = document.createElement('script');
     var code = document.createTextNode(scripts[i].textContent);
     s.appendChild(code);
-    var scriptAttrs = scripts[i].attributes
+    var scriptAttrs = scripts[i].attributes;
     for (var j = 0; j < scriptAttrs.length; j++) {
-      s.setAttribute(scriptAttrs[j].name, scriptAttrs[j].value)
+      s.setAttribute(scriptAttrs[j].name, scriptAttrs[j].value);
     }
     scripts[i].parentElement.replaceChild(s, scripts[i]);
   }

--- a/inst/rmarkdown/templates/xaringan/resources/js/script-tags.js
+++ b/inst/rmarkdown/templates/xaringan/resources/js/script-tags.js
@@ -1,14 +1,8 @@
 (function() {
   "use strict"
-  /* Replace <script> tags in slides area to make them executable
-   *
-   * Runs after post-processing of markdown source into slides and replaces only
-   * <script>s on the last slide of continued slides using the .has-continuation
-   * class added by xaringan. Finally, any <script>s in the slides area that
-   * aren't executed are commented out.
-   */
+  // Replace <script> tags in slides area to make them executable
   var scripts = document.querySelectorAll(
-    '.remark-slides-area .remark-slide-container:not(.has-continuation) script'
+    '.remark-slides-area .remark-slide-container script'
   );
   if (!scripts.length) return;
   for (var i = 0; i < scripts.length; i++) {
@@ -20,13 +14,5 @@
       s.setAttribute(scriptAttrs[j].name, scriptAttrs[j].value)
     }
     scripts[i].parentElement.replaceChild(s, scripts[i]);
-  }
-  var scriptsNotExecuted = document.querySelectorAll(
-    '.remark-slides-area .remark-slide-container.has-continuation script'
-  );
-  if (!scriptsNotExecuted.length) return;
-  for (var i = 0; i < scriptsNotExecuted.length; i++) {
-    var comment = document.createComment(scriptsNotExecuted[i].outerHTML)
-    scriptsNotExecuted[i].parentElement.replaceChild(comment, scriptsNotExecuted[i])
   }
 })();


### PR DESCRIPTION
@yihui This resolves #257. The main problem that issue brought up is that script tags like

```html
<script type="application/json" data-for="a1b2c3">/* json */</script>
```

were being re-written into a bare script tag.

```html
<script>/* ...json... */</script>
```

This PR fixes the above by ensuring that attributes are copied to the replaced `<script>` tag (5b475a8).

In light of this, it seems like it might not be worth the effort to work around slide continuations, so I removed that portion of the script in c8c6294.