### PR TITLE
Add nature option `restart_slideshow`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 - The `.pull-right` CSS class has been updated so that multiple `.pull-left`/`.pull-right` columns can be used on one slide (@gandebuie #271, thanks @ramongallego #260).
 
-- Add nature option `restart_slideshow` to restart a slideshow after it finished. Accepts `true` and numeric values in milliseconds. Only works if nature option `autoplay` is set.
+- Add nature option `autoplay` can take either a numeric value, or a list of the form `list(interval = N, loop = TRUE)`. The latter form can be used to specify if the autoplay should restart after reaching the last slide (i.e., go to the first slide). By default, the autoplay will not restart after reaching the last slide. See the help page `xaringan::moon_reader` for more information (thanks, @pat-s, #266).
 
 # CHANGES IN xaringan VERSION 0.16
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - The `.pull-right` CSS class has been updated so that multiple `.pull-left`/`.pull-right` columns can be used on one slide (@gandebuie #271, thanks @ramongallego #260).
 
+- Add nature option `restart_slideshow` to restart a slideshow after it finished. Accepts `true` and numeric values in milliseconds. Only works if nature option `autoplay` is set.
+
 # CHANGES IN xaringan VERSION 0.16
 
 ## BUG FIXES

--- a/R/render.R
+++ b/R/render.R
@@ -91,9 +91,9 @@ moon_reader = function(
   tmp_md = tempfile('xaringan', fileext = '.md')  # store md content here (bypass Pandoc)
   options(xaringan.page_number.offset = if (seal) 0L else -1L)
 
-  play_js = if (is.numeric(autoplay <- nature[['autoplay']]) && autoplay > 0)
-    sprintf('setInterval(function() {slideshow.gotoNextSlide();}, %d);', autoplay)
-  if (autoplay > 0) {
+  if (is.numeric(autoplay <- nature[['autoplay']]) && autoplay > 0) {
+    play_js = sprintf('setInterval(function() {slideshow.gotoNextSlide();}, %d);', autoplay)
+
     if (isTRUE(nature[['restart_slideshow']])) {
       play_js = append(play_js, sprintf('setInterval(function() {slideshow.gotoFirstSlide();}, slideshow.getSlideCount()*%d);', autoplay))
     } else if (is.numeric(nature[['restart_slideshow']])) {
@@ -101,6 +101,8 @@ moon_reader = function(
     } else {
       stop("restart_slideshow must be either 'true' or set to a numeric value in milliseconds.")
     }
+  } else {
+    play_js = NULL
   }
 
   if (isTRUE(countdown <- nature[['countdown']])) countdown = autoplay

--- a/R/render.R
+++ b/R/render.R
@@ -45,9 +45,12 @@
 #'   \code{autoplay} milliseconds. You can also set \code{countdown} to a number
 #'   (the number of milliseconds) to include a countdown timer on each slide. If
 #'   using \code{autoplay}, you can optionally set \code{countdown} to
-#'   \code{TRUE} to include a countdown equal to \code{autoplay}. To alter the
-#'   set of classes applied to the title slide, you can optionally set
-#'   \code{titleSlideClass} to a vector of classes; the default is
+#'   \code{TRUE} to include a countdown equal to \code{autoplay}. In addition,
+#'   when \code{autoplay} is set you can optionally restart the slideshow after
+#'   the last slide by either setting \code{restart_slideshow} to 'true' or by
+#'   passing an absolute value in milliseconds after which to start over again.
+#'   To alter the set of classes applied to the title slide, you can optionally
+#'   set \code{titleSlideClass} to a vector of classes; the default is
 #'   \code{c("center", "middle", "inverse")}.
 #' @param ... For \code{tsukuyomi()}, arguments passed to \code{moon_reader()};
 #'   for \code{moon_reader()}, arguments passed to
@@ -90,6 +93,15 @@ moon_reader = function(
 
   play_js = if (is.numeric(autoplay <- nature[['autoplay']]) && autoplay > 0)
     sprintf('setInterval(function() {slideshow.gotoNextSlide();}, %d);', autoplay)
+  if (autoplay > 0) {
+    if (isTRUE(nature[['restart_slideshow']])) {
+      play_js = append(play_js, sprintf('setInterval(function() {slideshow.gotoFirstSlide();}, slideshow.getSlideCount()*%d);', autoplay))
+    } else if (is.numeric(nature[['restart_slideshow']])) {
+      play_js = append(play_js, sprintf('setInterval(function() {slideshow.gotoFirstSlide();}, %d);', autoplay))
+    } else {
+      stop("restart_slideshow must be either 'true' or set to a numeric value in milliseconds.")
+    }
+  }
 
   if (isTRUE(countdown <- nature[['countdown']])) countdown = autoplay
   countdown_js = if (is.numeric(countdown) && countdown > 0) sprintf(

--- a/R/render.R
+++ b/R/render.R
@@ -42,16 +42,16 @@
 #'   \url{https://github.com/gnab/remark/wiki/Configuration}. Besides the
 #'   options provided by remark.js, you can also set \code{autoplay} to a number
 #'   (the number of milliseconds) so the slides will be played every
-#'   \code{autoplay} milliseconds. You can also set \code{countdown} to a number
-#'   (the number of milliseconds) to include a countdown timer on each slide. If
-#'   using \code{autoplay}, you can optionally set \code{countdown} to
-#'   \code{TRUE} to include a countdown equal to \code{autoplay}. In addition,
-#'   when \code{autoplay} is set you can optionally restart the slideshow after
-#'   the last slide by either setting \code{restart_slideshow} to 'true' or by
-#'   passing an absolute value in milliseconds after which to start over again.
-#'   To alter the set of classes applied to the title slide, you can optionally
-#'   set \code{titleSlideClass} to a vector of classes; the default is
-#'   \code{c("center", "middle", "inverse")}.
+#'   \code{autoplay} milliseconds; alternatively, \code{autoplay} can be a list
+#'   of the form \code{list(interval = N, loop = TRUE)}, so the slides will go
+#'   to the next page every \code{N} milliseconds, and optionally go back to the
+#'   first page to restart the play when \code{loop = TRUE}. You can also set
+#'   \code{countdown} to a number (the number of milliseconds) to include a
+#'   countdown timer on each slide. If using \code{autoplay}, you can optionally
+#'   set \code{countdown} to \code{TRUE} to include a countdown equal to
+#'   \code{autoplay}. To alter the set of classes applied to the title slide,
+#'   you can optionally set \code{titleSlideClass} to a vector of classes; the
+#'   default is \code{c("center", "middle", "inverse")}.
 #' @param ... For \code{tsukuyomi()}, arguments passed to \code{moon_reader()};
 #'   for \code{moon_reader()}, arguments passed to
 #'   \code{rmarkdown::\link{html_document}()}.
@@ -91,19 +91,15 @@ moon_reader = function(
   tmp_md = tempfile('xaringan', fileext = '.md')  # store md content here (bypass Pandoc)
   options(xaringan.page_number.offset = if (seal) 0L else -1L)
 
-  if (is.numeric(autoplay <- nature[['autoplay']]) && autoplay > 0) {
-    play_js = sprintf('setInterval(function() {slideshow.gotoNextSlide();}, %d);', autoplay)
-
-    if (isTRUE(nature[['restart_slideshow']])) {
-      play_js = append(play_js, sprintf('setInterval(function() {slideshow.gotoFirstSlide();}, slideshow.getSlideCount()*%d);', autoplay))
-    } else if (is.numeric(nature[['restart_slideshow']])) {
-      play_js = append(play_js, sprintf('setInterval(function() {slideshow.gotoFirstSlide();}, %d);', autoplay))
-    } else {
-      stop("restart_slideshow must be either 'true' or set to a numeric value in milliseconds.")
-    }
-  } else {
-    play_js = NULL
+  if (is.numeric(autoplay <- nature[['autoplay']])) {
+    autoplay = list(interval = autoplay, loop = FALSE)
   }
+  play_js = if (is.numeric(intv <- autoplay$interval) && intv > 0) sprintf(
+    'setInterval(function() {slideshow.gotoNextSlide();%s}, %d);',
+    if (!isTRUE(autoplay$loop)) '' else
+      ' if (slideshow.getCurrentSlideIndex() == slideshow.getSlideCount() - 1) slideshow.gotoFirstSlide();',
+    intv
+  )
 
   if (isTRUE(countdown <- nature[['countdown']])) countdown = autoplay
   countdown_js = if (is.numeric(countdown) && countdown > 0) sprintf(

--- a/inst/rmarkdown/templates/xaringan/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/xaringan/skeleton/skeleton.Rmd
@@ -284,7 +284,20 @@ DT::datatable(
           autoplay: 30000
     ```
 
---
+- If you want to restart the play after it reaches the last slide, you may set the sub-option `loop` to TRUE, e.g.,
+
+    ```yaml
+    output:
+      xaringan::moon_reader:
+        nature:
+          autoplay:
+            interval: 30000
+            loop: true
+    ```
+
+---
+
+# Some Tips
 
 - A countdown timer can be added to every page of the slides using the `countdown` option under `nature`, e.g. if you want to spend one minute on every page when you give the talk, you can set:
 

--- a/man/moon_reader.Rd
+++ b/man/moon_reader.Rd
@@ -59,9 +59,12 @@ options provided by remark.js, you can also set \code{autoplay} to a number
 \code{autoplay} milliseconds. You can also set \code{countdown} to a number
 (the number of milliseconds) to include a countdown timer on each slide. If
 using \code{autoplay}, you can optionally set \code{countdown} to
-\code{TRUE} to include a countdown equal to \code{autoplay}. To alter the
-set of classes applied to the title slide, you can optionally set
-\code{titleSlideClass} to a vector of classes; the default is
+\code{TRUE} to include a countdown equal to \code{autoplay}. In addition,
+when \code{autoplay} is set you can optionally restart the slideshow after
+the last slide by either setting \code{restart_slideshow} to 'true' or by
+passing an absolute value in milliseconds after which to start over again.
+To alter the set of classes applied to the title slide, you can optionally
+set \code{titleSlideClass} to a vector of classes; the default is
 \code{c("center", "middle", "inverse")}.}
 
 \item{...}{For \code{tsukuyomi()}, arguments passed to \code{moon_reader()};

--- a/man/moon_reader.Rd
+++ b/man/moon_reader.Rd
@@ -56,16 +56,16 @@ list(click = TRUE))}; see
 \url{https://github.com/gnab/remark/wiki/Configuration}. Besides the
 options provided by remark.js, you can also set \code{autoplay} to a number
 (the number of milliseconds) so the slides will be played every
-\code{autoplay} milliseconds. You can also set \code{countdown} to a number
-(the number of milliseconds) to include a countdown timer on each slide. If
-using \code{autoplay}, you can optionally set \code{countdown} to
-\code{TRUE} to include a countdown equal to \code{autoplay}. In addition,
-when \code{autoplay} is set you can optionally restart the slideshow after
-the last slide by either setting \code{restart_slideshow} to 'true' or by
-passing an absolute value in milliseconds after which to start over again.
-To alter the set of classes applied to the title slide, you can optionally
-set \code{titleSlideClass} to a vector of classes; the default is
-\code{c("center", "middle", "inverse")}.}
+\code{autoplay} milliseconds; alternatively, \code{autoplay} can be a list
+of the form \code{list(interval = N, loop = TRUE)}, so the slides will go
+to the next page every \code{N} milliseconds, and optionally go back to the
+first page to restart the play when \code{loop = TRUE}. You can also set
+\code{countdown} to a number (the number of milliseconds) to include a
+countdown timer on each slide. If using \code{autoplay}, you can optionally
+set \code{countdown} to \code{TRUE} to include a countdown equal to
+\code{autoplay}. To alter the set of classes applied to the title slide,
+you can optionally set \code{titleSlideClass} to a vector of classes; the
+default is \code{c("center", "middle", "inverse")}.}
 
 \item{...}{For \code{tsukuyomi()}, arguments passed to \code{moon_reader()};
 for \code{moon_reader()}, arguments passed to


### PR DESCRIPTION
fixes #265 

Restarts the slideshow after the summed up time set in `autoplay` (default) or optionally after a user supplied time (in ms).

I'm not bound to the option name - feel free to change it.

Preview: https://pat-s.me/slides/xaringan-restart/skeleton.html

---

To contribute to this repo, please make sure to:

- [x] Sign the CLA http://www.clahub.com/agreements/yihui/xaringan (if you haven't signed it before).
- [x] Add a news item to NEWS.md and your name to DESCRIPTION (by alphabetical order) unless you have already been listed there.
- [x] Provide a URL to a live example (and even better, a couple of screenshots) if you are contributing a new theme.

Thank you!
