### PR TITLE
Clear floats only on element immediately after .pull-right

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Small updates to KI theme (@ellessenne, #267).
 
+- The `.pull-right` CSS class has been updated so that multiple `.pull-left`/`.pull-right` columns can be used on one slide (@gandebuie #271, thanks @ramongallego #260).
+
 # CHANGES IN xaringan VERSION 0.16
 
 ## BUG FIXES

--- a/inst/rmarkdown/templates/xaringan/resources/default.css
+++ b/inst/rmarkdown/templates/xaringan/resources/default.css
@@ -41,7 +41,7 @@ a, a > code {
   float: right;
   width: 47%;
 }
-.pull-right ~ * {
+.pull-right + * {
   clear: both;
 }
 img, video, iframe {

--- a/inst/rmarkdown/templates/xaringan/resources/fc.css
+++ b/inst/rmarkdown/templates/xaringan/resources/fc.css
@@ -2,23 +2,23 @@
 
 .pull-left-70 { float: left; width: 66.5%; }
 .pull-right-30 { float: right; width: 28.5%; }
-.pull-right-30 ~ * { clear: both; }
+.pull-right-30 + * { clear: both; }
 
 .pull-left-60 { float: left; width: 57%; }
 .pull-right-40 { float: right; width: 38%; }
-.pull-right-40 ~ * { clear: both; }
+.pull-right-40 + * { clear: both; }
 
 .pull-left-50 { float: left; width: 47.5%; }
 .pull-right-50 { float: right; width: 47.5%; }
-.pull-right-50 ~ * { clear: both; }
+.pull-right-50 + * { clear: both; }
 
 .pull-left-40 { float: left; width: 38%; }
 .pull-right-60 { float: right; width: 57%; }
-.pull-right-60 ~ * { clear: both; }
+.pull-right-60 + * { clear: both; }
 
 .pull-left-30 { float: left; width: 28.5%; }
 .pull-right-70 { float: right; width: 66.5%; }
-.pull-right-70 ~ * { clear: both; }
+.pull-right-70 + * { clear: both; }
 
 /* headers and fonts*/
 h1, h2, h3 {

--- a/inst/rmarkdown/templates/xaringan/resources/ki.css
+++ b/inst/rmarkdown/templates/xaringan/resources/ki.css
@@ -128,7 +128,7 @@ ul {
   width: 45%;
 }
 
-.pull-right~* {
+.pull-right+* {
   clear: both;
 }
 

--- a/inst/rmarkdown/templates/xaringan/resources/middlebury.css
+++ b/inst/rmarkdown/templates/xaringan/resources/middlebury.css
@@ -75,7 +75,7 @@ a, a > code {
   width: 45%;
 }
 
-.pull-right ~ * {
+.pull-right + * {
   clear: both;
 }
 
@@ -145,7 +145,7 @@ thead, tfoot, tr:nth-child(even) { background: none; }
 
 /* H2 fonts */
 .title-slide h2 {
-  color: #4C4B4C; /* Middlebury grey accent 1 */ 
+  color: #4C4B4C; /* Middlebury grey accent 1 */
   font-size: 35px;
   text-align: left;
   text-shadow: none;
@@ -212,7 +212,7 @@ thead, tfoot, tr:nth-child(even) { background: none; }
   background-color: #AAA59F;
   color: #fff;
   padding-left: 100px;
-/*  text-shadow: 0 0 3px #333; */  
+/*  text-shadow: 0 0 3px #333; */
   text-align: center;
 }
 

--- a/inst/rmarkdown/templates/xaringan/resources/robot.css
+++ b/inst/rmarkdown/templates/xaringan/resources/robot.css
@@ -72,7 +72,7 @@ a:hover, a:hover > code {
   float: right;
   width: 47%;
 }
-.pull-right ~ * {
+.pull-right + * {
   clear: both;
 }
 img, video, iframe {

--- a/inst/rmarkdown/templates/xaringan/resources/rutgers.css
+++ b/inst/rmarkdown/templates/xaringan/resources/rutgers.css
@@ -66,7 +66,7 @@ a, a > code {
   width: 45%;
 }
 
-.pull-right ~ * {
+.pull-right + * {
   clear: both;
 }
 

--- a/inst/rmarkdown/templates/xaringan/resources/uol.css
+++ b/inst/rmarkdown/templates/xaringan/resources/uol.css
@@ -158,7 +158,7 @@ a:hover {
   width: 45%;
 }
 
-.pull-right ~ * {
+.pull-right + * {
   clear: both;
 }
 


### PR DESCRIPTION
This fixes the selector associated with the `.pull-right` class that currently clears left/right floats on *all* elements after a `.pull-right[]` div, rather than on the element _immediately after_ the `.pull-right`.

This is the root cause of #260 and ultimately causes misalignment of columns if multiple floats are used on a slide. With the default CSS `.pull-right ~ * { clear: both; }`, a second `.pull-right[]` appears on a new row.

![image](https://user-images.githubusercontent.com/5420529/88494094-6545e900-cf82-11ea-96e2-3263b2469840.png)

Replaced with `.pull-right + * { clear: both; }`, multiple columns render as intended.

![image](https://user-images.githubusercontent.com/5420529/88494146-a9d18480-cf82-11ea-82bf-e132ed6ba58e.png)

A few of the built-in themes were derived from `default.css`, so I updated those in a separate commit that can be reverted if desired.