### PR TITLE
fixing the alignment of the h1 h2 & h3 tags of the title slide (useR theme) 

### DIFF
--- a/inst/rmarkdown/templates/xaringan/resources/useR-fonts.css
+++ b/inst/rmarkdown/templates/xaringan/resources/useR-fonts.css
@@ -9,17 +9,14 @@ body { font-family: 'Droid Sans', 'Book Antiqua', Palatino, 'Microsoft YaHei', '
 
 h1 {
   font-family: 'Open Sans';
-  font-size: 36pt;
 }
 
 h2 {
   font-family: 'Open Sans';
-  font-size: 34pt;
 }
 
 h3 {
   font-family: 'Open Sans';
-  font-size: 32pt;
 }
 
 

--- a/inst/rmarkdown/templates/xaringan/resources/useR.css
+++ b/inst/rmarkdown/templates/xaringan/resources/useR.css
@@ -17,32 +17,30 @@
 }
 
 .title-slide h1 {
-  padding-top: 200px;
-  text-align: left;
+  padding-top: 50px;
+  text-align: center;
   padding-bottom: 2px;
   margin-bottom: 2px;
   font-weight: bold;
   color:#1B65B7;
   font-size: 34pt;
 
-
-
 }
 
 .title-slide h2 {
-  text-align: left;
+  text-align: center;
   padding-top: 0px;
   margin-top: 0px;
-  font-size: 24pt;
+  font-size: 26pt;
 
 }
 
 .title-slide h3 {
   text-align: left;
   text-shadow: none;
-  padding: 0px;
-  margin: 0px;
-  line-height: 1;
+  padding: 4px;
+  margin: 3px;
+  line-height: 1.1;
   font-size: 20pt;
 
 }

--- a/inst/rmarkdown/templates/xaringan/resources/useR.css
+++ b/inst/rmarkdown/templates/xaringan/resources/useR.css
@@ -9,29 +9,44 @@
   font-weight: bold;
 }
 
+
 .title-slide {
-  background-image: url("https://www.r-project.org/conferences/useR.png"), linear-gradient(to bottom, rgba(227, 227, 227) 100%, rgba(227, 227, 227) 100%), linear-gradient(to bottom, white 85%, rgba(227, 227, 227) 95%)  ;
-  background-position: 5% 15%, 0% 16%, center ;
-  background-size: 160px, 220px 140px , 100% 100%, cover ;
+  background-image: url("https://www.r-project.org/conferences/useR.png"), linear-gradient(to bottom, rgba(227, 227, 227) 100%, rgba(227, 227, 227) 100%), linear-gradient(to bottom, white 85%, rgba(227, 227, 227) 95%);
+  background-position: 5% 5%;
+  background-size: 250px;
 }
 
 .title-slide h1 {
-  position: absolute;
-  top: 60%;
-  left: 10%;
+  padding-top: 200px;
   text-align: left;
-  color: #454647;
+  padding-bottom: 2px;
+  margin-bottom: 2px;
   font-weight: bold;
+  color:#1B65B7;
+  font-size: 34pt;
+
+
+
+}
+
+.title-slide h2 {
+  text-align: left;
+  padding-top: 0px;
+  margin-top: 0px;
+  font-size: 24pt;
+
 }
 
 .title-slide h3 {
-  position: absolute;
-  top: 75%;
-  left: 10%;
   text-align: left;
-  color: #454647;
-  font-weight: normal;
+  text-shadow: none;
+  padding: 0px;
+  margin: 0px;
+  line-height: 1;
+  font-size: 20pt;
+
 }
+
 
 .chapter-slide {
   background-color: #1464b4;

--- a/inst/rmarkdown/templates/xaringan/resources/useR.css
+++ b/inst/rmarkdown/templates/xaringan/resources/useR.css
@@ -12,8 +12,9 @@
 
 .title-slide {
   background-image: url("https://www.r-project.org/conferences/useR.png"), linear-gradient(to bottom, rgba(227, 227, 227) 100%, rgba(227, 227, 227) 100%), linear-gradient(to bottom, white 85%, rgba(227, 227, 227) 95%);
-  background-position: 5% 5%;
-  background-size: 250px;
+  background-position: 1% 1%;
+  background-size: 200px;
+
 }
 
 .title-slide h1 {


### PR DESCRIPTION
Hi, 

I've fixed the alignment of the h1, h2 & h3 tags within the title slide and changed a little bit the style. Hope Joselyn enjoys it ^^

Best. 

------------------------------------------------------------------------------

To contribute to this repo, please make sure to:

- [ ] Sign the CLA (contributor license agreement). The CLA assistant will remind you below if you have not signed the agreement before.
- [ ] Add a news item to NEWS.md and your name to DESCRIPTION (by alphabetical order) unless you have already been listed there.
- [ ] Provide a URL to a live example (and even better, a couple of screenshots) if you are contributing a new theme.

Thank you!
