### PR TITLE
Add `highlight.source` to select highlighted line for remarkjs

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -189,7 +189,7 @@ moon_reader = function(
       source = function(x, options) {
         hook = hooks[['source']]
         res = hook(x, options)
-        highlight_code(res)
+        highlight_code(res, options)
       },
       output = function(x, options) {
         hook = hooks[['output']]

--- a/R/utils.R
+++ b/R/utils.R
@@ -91,7 +91,7 @@ summon_remark = function(version = 'latest', to = 'libs/') {
 
 # replace {{code}} with *code so that this line can be highlighted in remark.js;
 # this also works with multiple lines
-highlight_code = function(x) {
+highlight_code = function(x, options) {
   x = paste0('\n', x)  # prepend \n and remove it later
   r = '(\n)([ \t]*)\\{\\{(.+?)\\}\\}(?=(\n|$))'
   m = gregexpr(r, x, perl = TRUE)
@@ -105,6 +105,18 @@ highlight_code = function(x) {
   # catch `#<<` at end of the line but ignores lines that start with `*` since
   # they came from above
   x = gsub('^\\s?([^*].+?)\\s*#<<\\s*$', '*\\1', split_lines(x))
+  # allow to highlight line via option (useful for non R engine)
+  if (!is.null(i <- options$highlight.input)) {
+    if (!is.numeric(i)) {
+      w = sprintf("%s must be numeric. options will be ignored.", sQuote('highlight.input'))
+      warning(w, call. = FALSE)
+    } else {
+      s = grep('^`{3}', x) # find start of code output
+      i = s[1] + i
+      # ignore lines already marked as highlighted with `x`
+      x[i] = gsub('^\\s?([^*].+?)', '*\\1', x[i])
+    }
+  }
   paste(x, collapse = '\n')
 }
 


### PR DESCRIPTION
@gadenbuie here is what I tried so far quickly today. 

It makes this work
````markdown
---
output:
  xaringan::moon_reader:
    lib_dir: libs
    nature:
      highlightStyle: github
      highlightLines: true
      countIncrementalSlides: false
---

```{r include=FALSE}
library(DBI)
con <- dbConnect(RSQLite::SQLite(), dbname = ":memory:")
foo <- dbExecute(con, "DROP TABLE IF EXISTS packages")
foo <- dbExecute(con, "CREATE TABLE packages (id INTEGER, name TEXT)")
foo <- dbExecute(con, "INSERT INTO packages VALUES (1, 'readr'), (2, 'readxl'), (3, 'haven')")
```


## SQL

```{sql, connection = con, highlight.source = c(2)}
SELECT * 
FROM packages
```
````

but if used for R engine or other with chunk that contains more that one expression to evaluate, the index won't be ok. This for example means 2 source blocks and 2 output blocks
````markdown
```{r}
x <- 1
x
x + 2
```
````
using `collapse = TRUE` would also mix things up.

So translating the numeric index indexing passed by the user as seen in the source to the one after evaluation is trickier. It may need to be calculated earlier in the hook. 

Just sharing here as draft so that you see what I tried 😉 

