### PR TITLE
Add `servr::daemon_stop()` to the doc of `inf_mr()`

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -262,7 +262,7 @@ tsukuyomi = function(...) moon_reader(...)
 #' The Rmd document is compiled continuously to trap the world in the Infinite
 #' Tsukuyomi. The genjutsu is cast from the directory specified by
 #' \code{cast_from}, and the Rinne Sharingan will be reflected off of the
-#' \code{moon}.
+#' \code{moon}. Use `servr::daemon_stop()` to perform a genjutsu Kai and break the spell.
 #' @param moon The input Rmd file path (if missing and in RStudio, the current
 #'   active document is used).
 #' @param cast_from The root directory of the server.
@@ -369,6 +369,10 @@ infinite_moon_reader = function(moon, cast_from = '.', ...) {
 #' @export
 #' @rdname inf_mr
 inf_mr = infinite_moon_reader
+                     
+#' @export
+#' @rdname inf_mr
+mugen_tsukuyomi = infinite_moon_reader
 
 
 #' Convert HTML presentations to PDF via DeckTape


### PR DESCRIPTION
Hi,

Whenever I use `inf_mr()`, I always struggle to get out of it to test some code in the console without having to restart RStudio.

When you run `inf_mr()`, you get a hint from `{servr}` on how to get out, but it quickly becomes lost in the console output so I think it would be nice to have it in the documentation.

As a fellow Naruto nerd, I also propose a proper alternative name for it, as I found it sad that `tsukuyomi()` exists but not `mugen_tsukuyomi()`.

I don't think I would deserve to be in the contributors for such a minor PR so I dit not add my name to DESCRIPTION.

To contribute to this repo, please make sure to:

- [x] Sign the CLA (contributor license agreement). The CLA assistant will remind you below if you have not signed the agreement before.
- [ ] Add a news item to NEWS.md and your name to DESCRIPTION (by alphabetical order) unless you have already been listed there.

Thank you!
